### PR TITLE
fix: extract fresh keys from relocated chat data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install
+        run: python -m pip install --disable-pip-version-check . pytest
+      - name: Test
+        run: python -m pytest -q
+      - name: Compile entry points
+        run: python -m compileall -q chatlog_keeper tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install build and test dependencies
+        run: python -m pip install --disable-pip-version-check . pytest pyinstaller==6.20.0
+      - name: Verify tag matches package version
+        shell: pwsh
+        run: |
+          $version = python -c "import chatlog_keeper; print(chatlog_keeper.__version__)"
+          if ("v$version" -ne "${{ github.ref_name }}") {
+            throw "Tag ${{ github.ref_name }} does not match package version $version"
+          }
+      - name: Test
+        run: python -m pytest -q
+      - name: Build standalone executable
+        run: python -m PyInstaller packaging/chatlog_keeper.spec --noconfirm --clean --distpath dist_exe
+      - name: Smoke-test and checksum executable
+        shell: pwsh
+        run: |
+          .\dist_exe\chatlog-keeper.exe --help
+          $hash = (Get-FileHash -LiteralPath .\dist_exe\chatlog-keeper.exe -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  chatlog-keeper.exe" | Set-Content -LiteralPath .\dist_exe\chatlog-keeper.exe.sha256 -Encoding ascii -NoNewline
+      - name: Publish immutable GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" `
+            .\dist_exe\chatlog-keeper.exe `
+            .\dist_exe\chatlog-keeper.exe.sha256 `
+            --repo "${{ github.repository }}" `
+            --verify-tag `
+            --title "chatlog-keeper ${{ github.ref_name }}" `
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ niche is *newest-WeChat compatibility + QQ, with a clear legal stance*.
 Requires **Python 3.9+**.
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/labazhou2024/chatlog-keeper.git
 cd chatlog-keeper
 pip install -r requirements.txt
 ```
@@ -128,6 +128,9 @@ python -m chatlog_keeper.cli extract-key --source wechat --method passive
 # Debugger only (gets the key on the newest builds; higher ban risk — see
 #   "Account-ban risk"; needs Administrator + you log in once)
 python -m chatlog_keeper.cli extract-key --source wechat --method active
+
+# If you relocated WeChat data, pass its xwechat_files folder explicitly.
+python -m chatlog_keeper.cli extract-key --source wechat --method active --data-root "E:\xwechat_files"
 
 # Paste it yourself (after obtaining the key with any tool)
 python -m chatlog_keeper.cli set-key --source wechat --key <64-hex>

--- a/README.zh.md
+++ b/README.zh.md
@@ -76,7 +76,7 @@ chatlog-keeper 的不同之处：它是这里唯一能处理 **微信 4.1.10.31+
 需要 **Python 3.9+**。
 
 ```bash
-git clone <仓库地址>
+git clone https://github.com/labazhou2024/chatlog-keeper.git
 cd chatlog-keeper
 pip install -r requirements.txt
 ```
@@ -116,6 +116,9 @@ python -m chatlog_keeper.cli extract-key --source wechat --method passive
 
 # 只用调试器取 key（能取新版，封号风险更高——见“封号风险”；需管理员+登录一次）
 python -m chatlog_keeper.cli extract-key --source wechat --method active
+
+# 如果移动过微信数据目录，可显式指定 xwechat_files 文件夹
+python -m chatlog_keeper.cli extract-key --source wechat --method active --data-root "E:\xwechat_files"
 
 # 手动粘贴（你用其它工具拿到 key 之后）
 python -m chatlog_keeper.cli set-key --source wechat --key <64位十六进制>

--- a/chatlog_keeper/__init__.py
+++ b/chatlog_keeper/__init__.py
@@ -9,4 +9,4 @@ readers — pure standard library + pycryptodome, no telemetry, no network calls
 in the decryption path.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/chatlog_keeper/cli.py
+++ b/chatlog_keeper/cli.py
@@ -240,8 +240,8 @@ def _wechat_message_db_for_active(data_root: str | None = None) -> str | None:
     """Resolve the HMAC oracle DB for the active WeChat debugger.
 
     The PowerShell debugger accepts ``-DbPath`` rather than ``--data-root``.
-    Resolve that path in Python so relocated WeChat profiles such as
-    ``D:\\xwechat_files`` work the same way for export and active key extraction.
+    Resolve that path in Python so a profile relocated directly under any drive
+    root works the same way for export and active key extraction.
     """
 
     roots: list[Path] = []

--- a/chatlog_keeper/cli.py
+++ b/chatlog_keeper/cli.py
@@ -236,7 +236,44 @@ def _set_key(source: str, key: str) -> dict:
 
 # ─── automatic key extraction (passive memory scan / active debugger) ─────────
 
-def _extract_key(source: str, method: str) -> dict:
+def _wechat_message_db_for_active(data_root: str | None = None) -> str | None:
+    """Resolve the HMAC oracle DB for the active WeChat debugger.
+
+    The PowerShell debugger accepts ``-DbPath`` rather than ``--data-root``.
+    Resolve that path in Python so relocated WeChat profiles such as
+    ``D:\\xwechat_files`` work the same way for export and active key extraction.
+    """
+
+    roots: list[Path] = []
+    if data_root:
+        roots.append(Path(data_root).expanduser())
+    else:
+        root = wechat_db.find_weixin_data_root()
+        if root:
+            roots.append(root)
+
+    for root in roots:
+        try:
+            wxid_dirs = [root] if (root / "db_storage" / "message").exists() else wechat_db.find_wxid_dirs(root)
+        except OSError:
+            continue
+        for wxid_dir in wxid_dirs:
+            exact = wxid_dir / "db_storage" / "message" / "message_0.db"
+            try:
+                if exact.exists():
+                    return str(exact)
+                for db in wechat_db.find_msg_databases(wxid_dir):
+                    if db.name.lower() == "message_0.db":
+                        return str(db)
+                dbs = wechat_db.find_msg_databases(wxid_dir)
+                if dbs:
+                    return str(dbs[0])
+            except OSError:
+                continue
+    return None
+
+
+def _extract_key(source: str, method: str, data_root: str | None = None) -> dict:
     """Acquire a decryption key and cache it for later cache-first exports.
 
     ``method="passive"`` (default) scans the live client's process memory — low
@@ -246,15 +283,18 @@ def _extract_key(source: str, method: str) -> dict:
     freshly-launched client, but works on the newest builds. Active is opt-in:
     you accept the higher risk by choosing it explicitly.
     """
+    force_extract = os.environ.get("CHATLOG_FORCE_EXTRACT", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
     if method == "auto":
         # Try passive first (low ban risk); fall back to active (newer builds)
         # ONLY if passive finds nothing. Export stays cache-first and never
         # triggers active on its own — active only runs inside this command,
         # which the user invoked deliberately.
-        r = _extract_key(source, "passive")
+        r = _extract_key(source, "passive", data_root=data_root)
         if r.get("ok"):
             return r
-        r = _extract_key(source, "active")
+        r = _extract_key(source, "active", data_root=data_root)
         if isinstance(r, dict):
             r["fell_back_from_passive"] = True
         return r
@@ -263,27 +303,43 @@ def _extract_key(source: str, method: str) -> dict:
             key = active_key.extract_qq_key_active()
             if key and qq_db.save_cached_key(key):
                 return {"source": "qq", "method": "active", "ok": True,
-                        "key_len": len(key), "saved_to": str(qq_db._key_cache_path())}
+                        "key_len": len(key), "saved_to": str(qq_db._key_cache_path()),
+                        "fresh_extraction": True}
             return {"source": "qq", "method": "active", "ok": False,
                     "error": "active extraction got no key (not logged into the popped-up QQ / "
                              "UAC declined / unsupported build)"}
         reader = qq_db.QQDBReader()
         reader.initialize()  # cache → passive (timeout-bounded) → cache fallback
+        key_source = getattr(reader, "key_source", None)
+        if force_extract and key_source != "live":
+            return {"source": "qq", "method": "passive", "ok": False,
+                    "error": "fresh extraction was required but no live QQ key was obtained"}
         if reader.key and qq_db.save_cached_key(reader.key):
             return {"source": "qq", "method": "passive", "ok": True,
-                    "key_len": len(reader.key), "saved_to": str(qq_db._key_cache_path())}
+                    "key_len": len(reader.key), "saved_to": str(qq_db._key_cache_path()),
+                    "fresh_extraction": key_source == "live"}
         return {"source": "qq", "method": "passive", "ok": False,
                 "error": "passive scan found no key (QQ not running, or a newer build — "
                          "try `--method active` or `set-key`)"}
     if source == "wechat":
         if method == "active":
-            key = active_key.extract_wechat_key_active()
+            db_path = _wechat_message_db_for_active(data_root)
+            key = active_key.extract_wechat_key_active(db_path=db_path)
             if key and wechat_db.save_cached_wechat_key(key):
                 return {"source": "wechat", "method": "active", "ok": True,
-                        "key_len": len(key), "saved_to": str(wechat_db._wechat_key_cache_path())}
+                        "key_len": len(key), "saved_to": str(wechat_db._wechat_key_cache_path()),
+                        "db_path": db_path, "fresh_extraction": True}
+            if not db_path:
+                return {"source": "wechat", "method": "active", "ok": False,
+                        "error": "active extraction could not locate message_0.db for HMAC "
+                                 "verification (set --data-root to the xwechat_files folder)"}
             return {"source": "wechat", "method": "active", "ok": False,
                     "error": "active extraction got no key (not logged into the popped-up WeChat / "
-                             "UAC declined / unsupported build)"}
+                             "UAC declined / unsupported build)",
+                    "db_path": db_path}
+        if force_extract:
+            return {"source": "wechat", "method": "passive", "ok": False,
+                    "error": "fresh WeChat extraction requires --method active"}
         reader = wechat_db.WeChatDBReader()
         reader.initialize()
         enc = getattr(reader, "enc_keys", None)
@@ -365,7 +421,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "set-key":
         return _print_json(_set_key(args.source, args.key))
     if args.cmd == "extract-key":
-        return _print_json(_extract_key(args.source, args.method))
+        return _print_json(_extract_key(args.source, args.method, data_root=getattr(args, "data_root", None)))
     return 2
 
 

--- a/chatlog_keeper/export.py
+++ b/chatlog_keeper/export.py
@@ -102,7 +102,11 @@ footer { text-align: center; color: #b0b0b5; font-size: 12px;
 def _fmt_day(ts: float) -> str:
     if not ts:
         return "（未知日期）"
-    return datetime.fromtimestamp(ts).strftime("%Y 年 %m 月 %d 日")
+    # Python 3.9 on an English Windows locale can ask the locale codec to encode
+    # the whole strftime format string, which rejects the Chinese separators.
+    # Format only numeric fields in Python so the result is locale-independent.
+    dt = datetime.fromtimestamp(ts)
+    return f"{dt.year:04d} 年 {dt.month:02d} 月 {dt.day:02d} 日"
 
 
 def _fmt_clock(ts: float) -> str:

--- a/chatlog_keeper/qq_db.py
+++ b/chatlog_keeper/qq_db.py
@@ -59,8 +59,74 @@ class QQMessage:
 
 # ─── QQ Process helpers ───────────────────────────────────────────────────────
 
+def _qq_process_creation_ticks(pid: int) -> Optional[int]:
+    """Return a Windows process creation timestamp suitable for ordering.
+
+    NTQQ starts one root ``QQ.exe`` before its GPU/network/renderer helpers.
+    The database passphrase lives in the logged-in client process, while a
+    helper-first scan can consume the whole timeout without ever reaching it.
+    ``GetProcessTimes`` is local, fast, and does not require WMI/PowerShell.
+    """
+    if os.name != "nt":
+        return None
+    try:
+        kernel32 = ctypes.windll.kernel32
+        open_process = kernel32.OpenProcess
+        open_process.argtypes = [wt.DWORD, wt.BOOL, wt.DWORD]
+        open_process.restype = wt.HANDLE
+        get_process_times = kernel32.GetProcessTimes
+        get_process_times.argtypes = [
+            wt.HANDLE,
+            ctypes.POINTER(wt.FILETIME),
+            ctypes.POINTER(wt.FILETIME),
+            ctypes.POINTER(wt.FILETIME),
+            ctypes.POINTER(wt.FILETIME),
+        ]
+        get_process_times.restype = wt.BOOL
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [wt.HANDLE]
+        close_handle.restype = wt.BOOL
+
+        handle = open_process(0x1000, False, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+        if not handle:
+            return None
+        try:
+            created = wt.FILETIME()
+            exited = wt.FILETIME()
+            kernel = wt.FILETIME()
+            user = wt.FILETIME()
+            if not get_process_times(
+                handle,
+                ctypes.byref(created),
+                ctypes.byref(exited),
+                ctypes.byref(kernel),
+                ctypes.byref(user),
+            ):
+                return None
+            return (created.dwHighDateTime << 32) | created.dwLowDateTime
+        finally:
+            close_handle(handle)
+    except Exception:
+        return None
+
+
+def _rank_qq_pids(pids: List[int]) -> List[int]:
+    """Put the earliest (root) NTQQ process before later helper processes."""
+    unique = list(dict.fromkeys(pids))
+    observed_index = {pid: index for index, pid in enumerate(unique)}
+    creation = {pid: _qq_process_creation_ticks(pid) for pid in unique}
+    return sorted(
+        unique,
+        key=lambda pid: (
+            creation[pid] is None,
+            creation[pid] if creation[pid] is not None else observed_index[pid],
+            observed_index[pid],
+        ),
+    )
+
+
 def _get_qq_pids() -> list:
-    """Return list of QQ.exe PIDs."""
+    """Return QQ.exe PIDs with the root client before Chromium helpers."""
     try:
         r = subprocess.run(
             ["tasklist", "/FO", "CSV", "/FI", "IMAGENAME eq QQ.exe"],
@@ -75,7 +141,7 @@ def _get_qq_pids() -> list:
                     pids.append(int(parts[1]))
                 except ValueError:
                     pass
-        return sorted(pids, reverse=True)
+        return _rank_qq_pids(pids)
     except Exception as e:
         logger.warning(f"PID lookup failed: {e}")
         return []
@@ -547,8 +613,7 @@ def _scan_memory_for_key(pid: int, db_path: Path = None,
                                 seen.add(candidate)
                                 if db_raw and _verify_key_qq(candidate, db_raw):
                                     logger.info(
-                                        f"Passphrase verified at PID={pid} "
-                                        f"len={run_len} preview={candidate[:4]!r}…"
+                                        f"Passphrase verified at PID={pid} len={run_len}"
                                     )
                                     found = candidate
                                     break
@@ -583,12 +648,7 @@ def extract_key_from_qq(pid: int, db_path: Path = None,
     logger.info(f"Attempting passphrase extraction from QQ PID {pid}")
     key = _scan_memory_for_key(pid, db_path=db_path, timeout_s=timeout_s)
     if key:
-        # Don't log full passphrase; log length + first 4 chars
-        try:
-            preview = key.decode("ascii", errors="replace")[:4]
-        except Exception:
-            preview = "<binary>"
-        logger.info(f"Passphrase extracted: len={len(key)} preview={preview!r}…")
+        logger.info(f"Passphrase extracted: len={len(key)}")
     else:
         logger.warning("Passphrase extraction failed")
     return key
@@ -1656,6 +1716,7 @@ class QQDBReader:
         self.data_root = None
         self.db_path = None
         self.key = None
+        self.key_source = None  # "live" | "cache"; never contains key material
         self._initialized = False
     
     def initialize(self) -> bool:
@@ -1692,18 +1753,34 @@ class QQDBReader:
             if cached:
                 logger.info("Using cached key from data/secrets/qq_db.key (fast path)")
                 self.key = cached
+                self.key_source = "cache"
 
         # 1. Try live extraction if no cached key OR force_live
         if not self.key:
             pids = _get_qq_pids()
             if pids:
-                # Bound the passive scan — a large QQ.exe heap (multiple GB) can
-                # take many minutes; on timeout fall back to cache / `extract-key`.
-                scan_budget = float(os.environ.get("CHATLOG_QQ_SCAN_TIMEOUT_S", "120"))
+                # Bound the complete passive scan, not every QQ helper. The
+                # earliest/root process is attempted first; later helpers only
+                # receive the remaining wall-clock budget.
+                import time as _time
+                per_process_budget = max(
+                    0.1, float(os.environ.get("CHATLOG_QQ_SCAN_TIMEOUT_S", "120"))
+                )
+                total_budget = max(
+                    0.1, float(os.environ.get("CHATLOG_QQ_SCAN_TOTAL_S", "120"))
+                )
+                deadline = _time.monotonic() + total_budget
                 for pid in pids:
+                    remaining = deadline - _time.monotonic()
+                    if remaining <= 0:
+                        logger.warning(
+                            f"QQ passive scan exhausted total {total_budget:.0f}s budget"
+                        )
+                        break
                     self.key = extract_key_from_qq(pid, db_path=self.db_path,
-                                                   timeout_s=scan_budget)
+                                                   timeout_s=min(per_process_budget, remaining))
                     if self.key:
+                        self.key_source = "live"
                         if save_cached_key(self.key):
                             logger.info("Key extracted from QQ.exe and cached to data/secrets/qq_db.key")
                         break
@@ -1711,13 +1788,19 @@ class QQDBReader:
                     logger.warning("QQ running but key extraction failed (try Admin or different PID).")
 
         # 2. Final fallback (already tried above unless force_live)
-        if not self.key:
+        require_live = os.environ.get("CHATLOG_QQ_REQUIRE_LIVE_KEY", "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+        if not self.key and not require_live:
             cached = load_cached_key()
             if cached:
                 logger.info("Using cached key from data/secrets/qq_db.key (fallback)")
                 self.key = cached
+                self.key_source = "cache"
             else:
                 logger.warning("No key available (QQ.exe not running and no cached key).")
+        elif not self.key:
+            logger.warning("A fresh live QQ key was required; cached-key fallback is disabled.")
 
         self._initialized = True
         return self.db_path is not None

--- a/chatlog_keeper/scripts/windows_wechat_get_key.ps1
+++ b/chatlog_keeper/scripts/windows_wechat_get_key.ps1
@@ -837,9 +837,15 @@ function Get-DbPage1 {
 }
 
 function Find-WeixinMessageDb {
-    $roots = @('C:\wechat files\xwechat_files', 'D:\wechat files\xwechat_files',
-        (Join-Path $env:USERPROFILE 'Documents\xwechat_files'),
-        (Join-Path $env:USERPROFILE 'Documents\WeChat Files'))
+    $roots = @()
+    foreach ($drive in (Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue)) {
+        $roots += (Join-Path $drive.Root 'wechat files\xwechat_files')
+        $roots += (Join-Path $drive.Root 'xwechat_files')
+        $roots += (Join-Path $drive.Root 'WeChat Files')
+    }
+    $roots += (Join-Path $env:USERPROFILE 'Documents\xwechat_files')
+    $roots += (Join-Path $env:USERPROFILE 'Documents\WeChat Files')
+    $roots = @($roots | Select-Object -Unique)
     foreach ($root in $roots) {
         if (-not (Test-Path $root)) { continue }
         foreach ($wx in (Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue)) {

--- a/chatlog_keeper/wechat_db.py
+++ b/chatlog_keeper/wechat_db.py
@@ -117,13 +117,14 @@ def _get_weixin_pids() -> list:
 def find_weixin_data_root() -> Optional[Path]:
     """Locate the Weixin/WeChat user-data root, machine-neutrally.
 
-    The 4.x default is ``<drive>/wechat files/xwechat_files`` (user-relocatable to
-    any drive); 3.x used ``<Documents>/WeChat Files``. No drive letter is assumed.
+    The 4.x default is ``<drive>/wechat files/xwechat_files`` and users can also
+    relocate it directly to ``<drive>/xwechat_files``; 3.x used
+    ``<Documents>/WeChat Files``. No drive letter is assumed.
 
     Discovery order (nothing hardcoded):
       1. ``CHATLOG_WECHAT_DATA_ROOT`` env var (explicit override)
       2. every logical drive root: ``<drive>/wechat files/xwechat_files`` +
-         ``<drive>/WeChat Files``
+         ``<drive>/xwechat_files`` + ``<drive>/WeChat Files``
       3. real Documents + OneDrive variants
     """
     from chatlog_keeper.core._paths import all_drive_roots, candidate_documents_roots
@@ -134,6 +135,7 @@ def find_weixin_data_root() -> Optional[Path]:
         candidates.append(Path(env))
     for drive in all_drive_roots():
         candidates.append(drive / "wechat files" / "xwechat_files")
+        candidates.append(drive / "xwechat_files")
         candidates.append(drive / "WeChat Files")
     for doc in candidate_documents_roots():
         candidates.append(doc / "xwechat_files")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatlog-keeper"
-version = "0.1.0"
+version = "0.1.1"
 description = "Decrypt and export your own local QQ / WeChat chat history for personal backup and nostalgia. Local-only; nothing is uploaded."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -41,8 +41,8 @@ ocr = ["rapidocr-onnxruntime>=1.3"]    # optional OCR over decrypted images
 chatlog-keeper = "chatlog_keeper.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/labazhou2024/chatlog-keeper-oss"
-Source = "https://github.com/labazhou2024/chatlog-keeper-oss"
+Homepage = "https://github.com/labazhou2024/chatlog-keeper"
+Source = "https://github.com/labazhou2024/chatlog-keeper"
 
 [tool.setuptools.packages.find]
 include = ["chatlog_keeper*"]

--- a/tests/test_cli_extract_key.py
+++ b/tests/test_cli_extract_key.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from chatlog_keeper import cli
+
+
+def _mk_message_db(root: Path) -> Path:
+    db = root / "wxid_user_1234" / "db_storage" / "message" / "message_0.db"
+    db.parent.mkdir(parents=True)
+    db.write_bytes(b"x" * 4096)
+    return db
+
+
+def test_wechat_active_db_path_resolves_parent_data_root(tmp_path):
+    db = _mk_message_db(tmp_path / "xwechat_files")
+
+    assert cli._wechat_message_db_for_active(str(tmp_path / "xwechat_files")) == str(db)
+
+
+def test_wechat_active_db_path_resolves_wxid_data_root(tmp_path):
+    db = _mk_message_db(tmp_path / "xwechat_files")
+
+    assert cli._wechat_message_db_for_active(str(db.parents[2])) == str(db)
+
+
+def test_wechat_active_passes_db_path_to_debugger(monkeypatch, tmp_path):
+    db = _mk_message_db(tmp_path / "xwechat_files")
+    seen = {}
+
+    def fake_extract_wechat_key_active(**kwargs):
+        seen.update(kwargs)
+        return bytes(range(32))
+
+    monkeypatch.setattr(cli.active_key, "extract_wechat_key_active", fake_extract_wechat_key_active)
+    monkeypatch.setattr(cli.wechat_db, "save_cached_wechat_key", lambda key: key == bytes(range(32)))
+    monkeypatch.setattr(cli.wechat_db, "_wechat_key_cache_path", lambda: Path("wechat_db.key"))
+
+    result = cli._extract_key("wechat", "active", data_root=str(tmp_path / "xwechat_files"))
+
+    assert result["ok"] is True
+    assert result["db_path"] == str(db)
+    assert seen["db_path"] == str(db)

--- a/tests/test_cli_extract_key.py
+++ b/tests/test_cli_extract_key.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from chatlog_keeper import cli
+from chatlog_keeper import cli, wechat_db
+from chatlog_keeper.core import _paths
 
 
 def _mk_message_db(root: Path) -> Path:
@@ -39,3 +40,13 @@ def test_wechat_active_passes_db_path_to_debugger(monkeypatch, tmp_path):
     assert result["ok"] is True
     assert result["db_path"] == str(db)
     assert seen["db_path"] == str(db)
+
+
+def test_wechat_data_root_discovers_root_level_relocation(monkeypatch, tmp_path):
+    relocated = tmp_path / "xwechat_files"
+    relocated.mkdir()
+    monkeypatch.delenv("CHATLOG_WECHAT_DATA_ROOT", raising=False)
+    monkeypatch.setattr(_paths, "all_drive_roots", lambda: [tmp_path])
+    monkeypatch.setattr(_paths, "candidate_documents_roots", lambda: [])
+
+    assert wechat_db.find_weixin_data_root() == relocated

--- a/tests/test_force_extract.py
+++ b/tests/test_force_extract.py
@@ -1,0 +1,52 @@
+from chatlog_keeper import cli, qq_db
+
+
+def test_force_qq_rejects_cached_fallback(monkeypatch):
+    class CachedReader:
+        key = b"1234567890abcdef"
+        key_source = "cache"
+
+        def initialize(self):
+            return True
+
+    monkeypatch.setenv("CHATLOG_FORCE_EXTRACT", "1")
+    monkeypatch.setattr(cli.qq_db, "QQDBReader", CachedReader)
+
+    result = cli._extract_key("qq", "passive")
+
+    assert result["ok"] is False
+    assert "fresh extraction" in result["error"]
+
+
+def test_force_qq_marks_live_key_fresh(monkeypatch):
+    class LiveReader:
+        key = b"1234567890abcdef"
+        key_source = "live"
+
+        def initialize(self):
+            return True
+
+    monkeypatch.setenv("CHATLOG_FORCE_EXTRACT", "1")
+    monkeypatch.setattr(cli.qq_db, "QQDBReader", LiveReader)
+    monkeypatch.setattr(cli.qq_db, "save_cached_key", lambda key: True)
+    monkeypatch.setattr(cli.qq_db, "_key_cache_path", lambda: "qq_db.key")
+
+    result = cli._extract_key("qq", "passive")
+
+    assert result["ok"] is True
+    assert result["fresh_extraction"] is True
+
+
+def test_qq_reader_disables_cache_fallback_when_live_is_required(monkeypatch, tmp_path):
+    monkeypatch.setenv("CHATLOG_QQ_FORCE_LIVE_KEY", "1")
+    monkeypatch.setenv("CHATLOG_QQ_REQUIRE_LIVE_KEY", "1")
+    monkeypatch.setattr(qq_db, "find_qq_data_root", lambda: tmp_path)
+    monkeypatch.setattr(qq_db, "find_msg_database", lambda root: tmp_path / "nt_msg.db")
+    monkeypatch.setattr(qq_db, "_get_qq_pids", lambda: [])
+    monkeypatch.setattr(qq_db, "load_cached_key", lambda: b"1234567890abcdef")
+
+    reader = qq_db.QQDBReader()
+    reader.initialize()
+
+    assert reader.key is None
+    assert reader.key_source is None

--- a/tests/test_qq_passive_scan.py
+++ b/tests/test_qq_passive_scan.py
@@ -1,0 +1,56 @@
+import inspect
+import time
+
+from chatlog_keeper import qq_db
+
+
+def test_qq_pid_ranking_puts_earliest_root_before_newer_helpers(monkeypatch):
+    created = {23464: 300, 23116: 100, 22276: 200, 15924: 250}
+    monkeypatch.setattr(qq_db, "_qq_process_creation_ticks", created.get)
+
+    assert qq_db._rank_qq_pids([23464, 23116, 22276, 15924]) == [
+        23116,
+        22276,
+        15924,
+        23464,
+    ]
+
+
+def test_qq_pid_ranking_keeps_unknown_metadata_after_known_processes(monkeypatch):
+    created = {40: None, 30: 200, 20: 100}
+    monkeypatch.setattr(qq_db, "_qq_process_creation_ticks", created.get)
+
+    assert qq_db._rank_qq_pids([40, 30, 20]) == [20, 30, 40]
+
+
+def test_qq_initialize_uses_one_total_passive_budget(monkeypatch, tmp_path):
+    db_path = tmp_path / "nt_msg.db"
+    db_path.write_bytes(b"x" * 8192)
+    monkeypatch.setenv("CHATLOG_QQ_SCAN_TIMEOUT_S", "120")
+    monkeypatch.setenv("CHATLOG_QQ_SCAN_TOTAL_S", "120")
+    monkeypatch.setattr(qq_db, "find_qq_data_root", lambda: tmp_path)
+    monkeypatch.setattr(qq_db, "find_msg_database", lambda root: db_path)
+    monkeypatch.setattr(qq_db, "load_cached_key", lambda: None)
+    monkeypatch.setattr(qq_db, "_get_qq_pids", lambda: [10, 20, 30])
+
+    clock = {"value": 0.0}
+    calls = []
+
+    def fake_scan(pid, db_path=None, timeout_s=None):
+        calls.append((pid, timeout_s))
+        clock["value"] += timeout_s
+        return None
+
+    monkeypatch.setattr(qq_db, "extract_key_from_qq", fake_scan)
+    monkeypatch.setattr(time, "monotonic", lambda: clock["value"])
+
+    reader = qq_db.QQDBReader()
+    assert reader.initialize() is True
+    assert calls == [(10, 120.0)]
+    assert reader.key is None
+
+
+def test_qq_passive_logs_never_include_key_preview():
+    source = inspect.getsource(qq_db)
+    assert "preview={candidate" not in source
+    assert "Passphrase extracted: len={len(key)} preview=" not in source


### PR DESCRIPTION
## Summary
- pass Memexa-discovered WeChat message DB to the elevated extractor
- discover root-level xwechat_files relocations on every drive
- make QQ fresh-key scans bounded and cache provenance explicit
- prepare v0.1.1 with Windows CI and reproducible release builds

## Validation
- 31 pytest tests passed
- compileall passed
- diff/check and private-path/secret/network/risky-exec audit passed