### PR TITLE
feat: add Apple Silicon macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ permissions:
 
 jobs:
   tests:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-latest, macos-15]
         python-version: ["3.9", "3.12"]
     steps:
       - name: Check out source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,47 @@ permissions:
   contents: write
 
 jobs:
+  build-macos:
+    runs-on: macos-15
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install build and test dependencies
+        run: python -m pip install --disable-pip-version-check . pytest pyinstaller==6.20.0
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          version="$(python -c 'import chatlog_keeper; print(chatlog_keeper.__version__)')"
+          test "v${version}" = "${{ github.ref_name }}"
+      - name: Test
+        run: python -m pytest -q
+      - name: Build Apple Silicon standalone executable
+        run: |
+          python -m PyInstaller packaging/chatlog_keeper.spec --noconfirm --clean --distpath dist_exe
+          mv dist_exe/chatlog-keeper dist_exe/chatlog-keeper-macos-arm64
+          chmod 755 dist_exe/chatlog-keeper-macos-arm64
+      - name: Smoke-test architecture and checksum
+        run: |
+          dist_exe/chatlog-keeper-macos-arm64 --help
+          file dist_exe/chatlog-keeper-macos-arm64 | grep -q "Mach-O 64-bit executable arm64"
+          shasum -a 256 dist_exe/chatlog-keeper-macos-arm64 \
+            | sed 's#dist_exe/##' > dist_exe/chatlog-keeper-macos-arm64.sha256
+      - name: Upload macOS release inputs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: chatlog-keeper-macos-arm64
+          path: |
+            dist_exe/chatlog-keeper-macos-arm64
+            dist_exe/chatlog-keeper-macos-arm64.sha256
+          if-no-files-found: error
+
   build-and-release:
+    needs: build-macos
     runs-on: windows-latest
     steps:
       - name: Check out source
@@ -38,6 +78,11 @@ jobs:
           .\dist_exe\chatlog-keeper.exe --help
           $hash = (Get-FileHash -LiteralPath .\dist_exe\chatlog-keeper.exe -Algorithm SHA256).Hash.ToLowerInvariant()
           "$hash  chatlog-keeper.exe" | Set-Content -LiteralPath .\dist_exe\chatlog-keeper.exe.sha256 -Encoding ascii -NoNewline
+      - name: Download macOS release inputs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: chatlog-keeper-macos-arm64
+          path: dist_macos
       - name: Publish immutable GitHub Release
         shell: pwsh
         env:
@@ -46,6 +91,8 @@ jobs:
           gh release create "${{ github.ref_name }}" `
             .\dist_exe\chatlog-keeper.exe `
             .\dist_exe\chatlog-keeper.exe.sha256 `
+            .\dist_macos\chatlog-keeper-macos-arm64 `
+            .\dist_macos\chatlog-keeper-macos-arm64.sha256 `
             --repo "${{ github.repository }}" `
             --verify-tag `
             --title "chatlog-keeper ${{ github.ref_name }}" `

--- a/README.md
+++ b/README.md
@@ -40,14 +40,18 @@ grouped by conversation and day — the way you remember it).
 - **QQ** — export your local NTQQ chat history
 - **WeChat** — export your local WeChat chat history
 - **WeChat images** — restore local `.dat` images back to `jpg` / `png`
+- **Windows + macOS** — one CLI and export format on Windows 11 and Apple
+  Silicon Macs
 
 ## Supported versions
 
-| Source | Supported | Page-key derivation | How the key is obtained |
+| Platform | Source / tested client | Page-key derivation | Key flow |
 |---|---|---|---|
-| WeChat ≤ 4.0.x | ✅ | raw-key (`enc_key` used directly) | passive memory scan |
-| WeChat 4.1.10.31+ (2026-05) | ✅ | password mode — `PBKDF2-HMAC-SHA512(enc_key, salt, 256000)` | one-time debugger (key no longer kept in plaintext memory) |
-| QQ NTQQ 9.9.x | ✅ | per-DB passphrase | passive scan |
+| Windows | WeChat ≤ 4.0.x | raw-key (`enc_key` used directly) | passive memory scan |
+| Windows | WeChat 4.1.10.31+ | password mode — `PBKDF2-HMAC-SHA512(enc_key, salt, 256000)` | one-time debugger |
+| Windows | QQ NTQQ 9.9.x | per-DB passphrase | passive scan or one-time debugger |
+| macOS arm64 | WeChat 4.1.9 (build 268575) | raw/password mode selected by page-1 HMAC | passive scan or isolated debug copy |
+| macOS arm64 | QQ 6.9.95 (build 36385) | per-DB passphrase | passive scan or isolated debug copy |
 
 On **WeChat 4.1.10.31** (released 2026-05-27) the plaintext key was moved out of
 the process heap, so a passive memory scan — what most existing tools rely on —
@@ -61,7 +65,7 @@ and maintenance status change over time — please check each repo yourself):
 
 | Tool | Stars | Last update | WeChat | QQ | Platform | Notes |
 |---|---|---|---|---|---|---|
-| **chatlog-keeper** (this) | — | 2026-06 | ≤4.0 **+ 4.1.10.31+** | ✅ NTQQ | Windows | passive scan + debugger fallback |
+| **chatlog-keeper** (this) | — | 2026-07 | ≤4.0 **+ 4.1.x** | ✅ NTQQ | Windows + macOS arm64 | passive scan + isolated active fallback |
 | [WeChatMsg / 留痕](https://github.com/LC044/WeChatMsg) | 41k+ | 2025-12 | ≤4.0 | ❌ | Windows | feature-rich GUI; author states it is **no longer updated** |
 | [PyWxDump](https://github.com/xaoyaoo/PyWxDump) | 9k+ | 2025-10 | 3.x–4.0 | ❌ | Windows | repo description now reads "删库"; inactive |
 | [chatlog](https://github.com/sjzar/chatlog) | 9k+ | 2025-10 | ≤4.0 | ❌ | cross-platform | Go; HTTP/MCP API |
@@ -71,10 +75,10 @@ Where chatlog-keeper differs: it is the one here that handles **WeChat
 4.1.10.31+** (where the key left plaintext memory) and that also exports **QQ
 (NTQQ)**, not just WeChat.
 
-What it is **not**: it is **Windows-only**, a young project, and deliberately
-CLI-first (JSON/HTML, no GUI or built-in analytics). If you want a polished GUI
-or cross-platform support today, the tools above are more mature — this one's
-niche is *newest-WeChat compatibility + QQ, with a clear legal stance*.
+What it is **not**: it is still a young, deliberately CLI-first project
+(JSON/HTML, no built-in analytics). The macOS release currently targets Apple
+Silicon. The niche is *current WeChat compatibility + QQ on both desktop
+platforms, with a clear legal and local-only boundary*.
 
 ## Install
 
@@ -83,8 +87,13 @@ Requires **Python 3.9+**.
 ```bash
 git clone https://github.com/labazhou2024/chatlog-keeper.git
 cd chatlog-keeper
-pip install -r requirements.txt
+python -m pip install .
 ```
+
+Tagged releases also provide a standalone `chatlog-keeper.exe` for Windows and
+`chatlog-keeper-macos-arm64` for Apple Silicon. The standalone Mac build
+contains its read-only Mach helper; a source install compiles that tiny audited
+C helper on first key scan and therefore needs Xcode Command Line Tools.
 
 ## Usage
 
@@ -125,20 +134,30 @@ python -m chatlog_keeper.cli extract-key --source wechat
 # Passive only (lowest ban risk; may find nothing on WeChat 4.1.10.31+)
 python -m chatlog_keeper.cli extract-key --source wechat --method passive
 
-# Debugger only (gets the key on the newest builds; higher ban risk — see
-#   "Account-ban risk"; needs Administrator + you log in once)
+# Active only (newest builds; needs system-administrator authorization and may
+# require one login in a separately launched client)
 python -m chatlog_keeper.cli extract-key --source wechat --method active
 
 # If you relocated WeChat data, pass its xwechat_files folder explicitly.
+# Windows example:
 python -m chatlog_keeper.cli extract-key --source wechat --method active --data-root "E:\xwechat_files"
+
+# macOS example:
+python -m chatlog_keeper.cli extract-key --source wechat --method active \
+  --data-root "$HOME/Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files"
 
 # Paste it yourself (after obtaining the key with any tool)
 python -m chatlog_keeper.cli set-key --source wechat --key <64-hex>
 python -m chatlog_keeper.cli set-key --source qq --key <16-char passphrase>
 ```
 
-The key is cached locally (`%LOCALAPPDATA%\chatlog-keeper\data\secrets\`) and
-reused on later exports — no need to fetch it again.
+The key is cached locally and reused on later exports:
+
+- Windows: `%LOCALAPPDATA%\chatlog-keeper\data\secrets\`
+- macOS: `~/Library/Application Support/chatlog-keeper/secrets/`
+
+On macOS the secrets directory is mode `0700` and each key file is `0600`.
+See [the macOS security and troubleshooting guide](docs/macos.md).
 
 ## Account-ban risk
 
@@ -154,7 +173,8 @@ The actual risk **depends on how the key is obtained**:
 |---|---|---|
 | Reading the local database file | Negligible (≈0) | Pure file read; no network; the server cannot perceive it |
 | Passive memory scan for the key (default) | Low | Read-only process memory (no injection, no hooks, no debugger); long used by mainstream tools with no reported bans |
-| Debugger-breakpoint extraction (`--method active`) | Medium–high | Attaches a debugger to the client — the only path with a documented detection mechanism (a client may detect "being debugged / non-allowlisted module loaded"). Use only when passive fails, at your own discretion |
+| Windows active extraction | Medium–high | Launches a separate debugged client and reads the key at the cipher boundary. Use only when passive fails |
+| macOS active extraction | Elevated / compatibility-sensitive | Never changes the original app or disables SIP; it launches a private ad-hoc-signed copy and performs an administrator-authorized read-only Mach scan |
 
 To minimize risk: prefer the default passive method; reuse the cache instead of
 re-extracting; you can even quit the client and decrypt offline afterwards; and
@@ -176,6 +196,10 @@ computer that you already have the right to access**, and it never goes online.
 
 > Decryption is page-by-page streaming (peak memory ≈ one 4 KB page), so even a
 > multi-GB database is never loaded whole.
+
+Live databases are first copied as a consistent private family (`db`, `-wal`,
+`-shm`). On APFS this uses clone-copy; committed WeChat WAL frames are
+HMAC-verified before being applied to the decrypted output.
 
 ## Legal & Disclaimer
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,14 +39,17 @@
 - **QQ**：导出 NTQQ 本地聊天记录
 - **微信**：导出 WeChat 本地聊天记录
 - **微信图片**：把本地 `.dat` 加密图片还原成 `jpg` / `png`
+- **Windows + macOS**：Windows 11 与 Apple Silicon Mac 使用同一套 CLI 和导出格式
 
 ## 支持的版本
 
-| 来源 | 支持 | page-key 派生 | 怎么拿 key |
+| 平台 | 来源 / 实测客户端 | page-key 派生 | 取 key 方式 |
 |---|---|---|---|
-| 微信 ≤ 4.0.x | ✅ | raw-key（`enc_key` 直接用） | 被动内存扫描 |
-| 微信 4.1.10.31+（2026-05） | ✅ | password 模式 —— `PBKDF2-HMAC-SHA512(enc_key, salt, 256000)` | 调试器取一次（key 不再以明文留在内存） |
-| QQ NTQQ 9.9.x | ✅ | 每库口令 | 被动扫描 |
+| Windows | 微信 ≤ 4.0.x | raw-key（`enc_key` 直接用） | 被动内存扫描 |
+| Windows | 微信 4.1.10.31+ | password 模式 —— `PBKDF2-HMAC-SHA512(enc_key, salt, 256000)` | 一次性调试器 |
+| Windows | QQ NTQQ 9.9.x | 每库口令 | 被动扫描或一次性调试器 |
+| macOS arm64 | 微信 4.1.9（build 268575） | 由 page-1 HMAC 自动选择 raw/password 模式 | 被动扫描或隔离调试副本 |
+| macOS arm64 | QQ 6.9.95（build 36385） | 每库口令 | 被动扫描或隔离调试副本 |
 
 **微信 4.1.10.31**（2026-05-27 发布）把明文 key 移出了进程堆，因此被动内存扫描
 ——多数现有工具依赖的方式——在这些版本上**取不到 key**。chatlog-keeper 会对这些
@@ -58,7 +61,7 @@
 
 | 工具 | Star | 最近更新 | 微信 | QQ | 平台 | 备注 |
 |---|---|---|---|---|---|---|
-| **chatlog-keeper**（本项目） | — | 2026-06 | ≤4.0 **+ 4.1.10.31+** | ✅ NTQQ | Windows | 被动扫描 + 调试器兜底 |
+| **chatlog-keeper**（本项目） | — | 2026-07 | ≤4.0 **+ 4.1.x** | ✅ NTQQ | Windows + macOS arm64 | 被动扫描 + 隔离主动流程兜底 |
 | [WeChatMsg / 留痕](https://github.com/LC044/WeChatMsg) | 41k+ | 2025-12 | ≤4.0 | ❌ | Windows | 功能丰富的 GUI；作者声明**不再更新** |
 | [PyWxDump](https://github.com/xaoyaoo/PyWxDump) | 9k+ | 2025-10 | 3.x–4.0 | ❌ | Windows | 仓库描述现为“删库”；已停更 |
 | [chatlog](https://github.com/sjzar/chatlog) | 9k+ | 2025-10 | ≤4.0 | ❌ | 跨平台 | Go；提供 HTTP/MCP API |
@@ -67,9 +70,9 @@
 chatlog-keeper 的不同之处：它是这里唯一能处理 **微信 4.1.10.31+**（key 已离开
 明文内存）、并且**同时导出 QQ（NTQQ）**而不只是微信的工具。
 
-它**不追求**的：**仅 Windows**、是个新项目、刻意以 CLI 为先（JSON/HTML，无 GUI、
-无内置分析）。如果你现在就想要成熟的 GUI 或跨平台支持，上面那些工具更成熟——
-本项目的定位是*兼容最新版微信 + 支持 QQ，且法律边界清晰*。
+它仍是一个新项目，并且刻意以 CLI 为先（JSON/HTML，无内置分析）；macOS 独立包目前
+只覆盖 Apple Silicon。本项目的定位是*在两个桌面平台兼容当前微信 + QQ，且本地与法律
+边界清晰*。
 
 ## 安装
 
@@ -78,8 +81,12 @@ chatlog-keeper 的不同之处：它是这里唯一能处理 **微信 4.1.10.31+
 ```bash
 git clone https://github.com/labazhou2024/chatlog-keeper.git
 cd chatlog-keeper
-pip install -r requirements.txt
+python -m pip install .
 ```
+
+正式 tag 还提供 Windows `chatlog-keeper.exe` 和 Apple Silicon
+`chatlog-keeper-macos-arm64` 独立文件。Mac 独立包已经内置只读 Mach helper；源码安装
+会在首次取 key 时编译这段可审计的 C helper，因此需要 Xcode Command Line Tools。
 
 ## 使用
 
@@ -114,18 +121,28 @@ python -m chatlog_keeper.cli extract-key --source wechat
 # 只用被动扫描（封号风险最低；新版微信 4.1.10.31+ 可能取不到）
 python -m chatlog_keeper.cli extract-key --source wechat --method passive
 
-# 只用调试器取 key（能取新版，封号风险更高——见“封号风险”；需管理员+登录一次）
+# 只走主动流程（新版；需系统管理员授权，隔离客户端可能要再登录一次）
 python -m chatlog_keeper.cli extract-key --source wechat --method active
 
-# 如果移动过微信数据目录，可显式指定 xwechat_files 文件夹
+# 如果移动过微信数据目录，可显式指定 xwechat_files 文件夹（Windows 示例）
 python -m chatlog_keeper.cli extract-key --source wechat --method active --data-root "E:\xwechat_files"
+
+# macOS 示例
+python -m chatlog_keeper.cli extract-key --source wechat --method active \
+  --data-root "$HOME/Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files"
 
 # 手动粘贴（你用其它工具拿到 key 之后）
 python -m chatlog_keeper.cli set-key --source wechat --key <64位十六进制>
 python -m chatlog_keeper.cli set-key --source qq --key <16位口令>
 ```
 
-取到的 key 会缓存在本机（`%LOCALAPPDATA%\chatlog-keeper\data\secrets\`），之后导出直接复用，无需重复获取。
+取到的 key 会缓存在本机，之后导出直接复用：
+
+- Windows：`%LOCALAPPDATA%\chatlog-keeper\data\secrets\`
+- macOS：`~/Library/Application Support/chatlog-keeper/secrets/`
+
+macOS 上 secrets 目录权限为 `0700`，每个 key 文件为 `0600`。详细见
+[macOS 安全与排障说明](docs/macos.zh.md)。
 
 ## 封号风险
 
@@ -137,7 +154,8 @@ python -m chatlog_keeper.cli set-key --source qq --key <16位口令>
 |---|---|---|
 | 读本地数据库文件 | 极低（≈0） | 纯文件读取，不碰网络，服务器无从感知 |
 | 被动内存扫描取 key（默认） | 低 | 只读进程内存（不注入、不 hook、不附加调试器）；社区主流工具长期采用，未见因此被封的实证 |
-| 调试器断点取 key（`--method active`） | 中–偏高 | 会附加调试器到客户端进程，是唯一有实证检测机制的路径（客户端可能检测“被调试 / 加载非白名单模块”）。仅在被动取不到时再用，自行权衡 |
+| Windows 主动取 key | 中–偏高 | 启动独立受调试客户端，在密码边界读取 key；仅在被动方式失败时使用 |
+| macOS 主动取 key | 权限较高 / 兼容性敏感 | 不修改原应用、不关闭 SIP；启动私有 ad-hoc 签名副本，经管理员授权做只读 Mach 扫描 |
 
 降低风险：优先用默认的被动方式；能用缓存就不重复取 key；取到 key 后甚至可以退出客户端、离线解密；**绝不**用本工具做任何服务器侧自动化操作（那才是真正的封号高发区）。
 
@@ -152,6 +170,9 @@ python -m chatlog_keeper.cli set-key --source qq --key <16位口令>
 
 > 解密采用逐页流式处理（峰值内存约等于一个 4 KB 内存页），即使是好几个 GB 的数据库，
 > 也不会被整个读进内存。
+
+对正在使用的数据库，工具会先一致性快照 `db`、`-wal`、`-shm` 文件族；APFS 上使用
+clone-copy。微信已提交的 WAL frame 会先逐页通过 HMAC 校验，再写入解密副本。
 
 ## 法律与免责
 

--- a/chatlog_keeper/__init__.py
+++ b/chatlog_keeper/__init__.py
@@ -9,4 +9,4 @@ readers — pure standard library + pycryptodome, no telemetry, no network calls
 in the decryption path.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/chatlog_keeper/active_key.py
+++ b/chatlog_keeper/active_key.py
@@ -11,19 +11,22 @@ builds, but:
 * **QQ NT** keeps a 16-char passphrase in the heap, but the process can hold
   1+ GB, so a full scan can take many minutes.
 
-For those cases this module drives two bundled PowerShell debugger scripts
+On Windows this module drives two bundled PowerShell debugger scripts
 (``scripts/windows_ntqq_get_key.ps1`` / ``scripts/windows_wechat_get_key.ps1``).
 Each one is a pure .NET/Win32 debugger — ``CreateProcessW(DEBUG_ONLY_THIS_PROCESS)``
 launches a *fresh* client, sets an INT3 software breakpoint on the SQLCipher
-key-set function, and reads the key from registers when it fires. The key is
-verified by an HMAC oracle against your own DB's page 1, so a wrong guess can
-never be returned. No DLL injection, no third-party binary, nothing uploaded.
+key-set function, and reads the key from registers when it fires.
 
-This needs Administrator rights (a debugger has to attach) and you have to log
-into the freshly-launched client once. After that the key is cached and every
-later export reads the cache — no scan, no debugger, no login.
+On macOS the original signed app is left untouched. An isolated copy under the
+tool's Application Support directory is ad-hoc signed with
+``com.apple.security.get-task-allow``, launched separately, and scanned through
+a bundled read-only Mach helper after explicit administrator authorization.
+SIP is never disabled and nothing is injected into either client.
 
-Everything here is Windows-only and operates on **your own** logged-in client.
+Every candidate on either platform is verified by an HMAC oracle against your
+own DB page 1 before it can be returned or cached. The active flow requires
+administrator authorization and may require logging into the isolated client
+once. Later exports use the private local cache.
 """
 from __future__ import annotations
 
@@ -254,6 +257,7 @@ def _run_active(script: Path, args: List[str], timeout: int,
 # ─── public API ───────────────────────────────────────────────────────────────
 
 def extract_qq_key_active(*, wrapper_node: Optional[str] = None,
+                          db_path: Optional[str] = None,
                           analyze_only: bool = False,
                           timeout: int = 600) -> Optional[bytes]:
     """Extract the QQ NT 16-char passphrase via the debugger script.
@@ -263,6 +267,48 @@ def extract_qq_key_active(*, wrapper_node: Optional[str] = None,
     not launch/debug QQ) — useful to verify the script runs on this machine
     without closing or restarting the user's QQ.
     """
+    if sys.platform == "darwin":
+        if analyze_only:
+            from chatlog_keeper.macos_key import ensure_helper
+            ensure_helper()
+            return None
+        from chatlog_keeper import qq_db
+        from chatlog_keeper.macos_debug_app import launch_debug_copy
+        from chatlog_keeper.macos_key import extract_verified
+        resolved = Path(db_path) if db_path else None
+        if not resolved:
+            root = qq_db.find_qq_data_root()
+            resolved = qq_db.find_msg_database(root) if root else None
+        if not resolved or not resolved.is_file():
+            return None
+        debug_pid = launch_debug_copy("qq")
+        if not debug_pid:
+            # The daily signed client does not carry get-task-allow. Falling
+            # back to it would only trigger an administrator prompt followed
+            # by a guaranteed SIP/taskgated denial.
+            return None
+        # A first login/checkpoint can replace page 1 while the helper scans.
+        # Verify against a stable pre-scan oracle, then re-read and confirm on
+        # the current DB family before returning a cacheable key.  Retry once
+        # on a real checkpoint race; never accept a stale-page-only match.
+        for _attempt in range(2):
+            db_raw = qq_db._read_qq_verification_bytes(resolved)
+            if not db_raw:
+                return None
+            key = extract_verified(
+                "qq", debug_pid,
+                lambda candidate: qq_db._verify_key_qq(candidate, db_raw),
+                primary_verify=lambda candidate: qq_db._verify_key_qq_with_algo(
+                    candidate, db_raw, "sha512", "sha1", 48
+                ),
+                elevate=True, timeout=timeout,
+            )
+            if not key:
+                return None
+            latest = qq_db._read_qq_verification_bytes(resolved)
+            if latest and qq_db._verify_key_qq(key, latest):
+                return key
+        return None
     if os.name != "nt":
         logger.warning("active QQ extraction is Windows-only")
         return None
@@ -294,6 +340,41 @@ def extract_wechat_key_active(*, weixin_dll: Optional[str] = None,
     Returns the 32-byte master key, or None. ``analyze_only`` runs static
     analysis only (``-NoDebugForKey``) and never launches/restarts WeChat.
     """
+    if sys.platform == "darwin":
+        if analyze_only:
+            from chatlog_keeper.macos_key import ensure_helper
+            ensure_helper()
+            return None
+        from chatlog_keeper import wechat_db
+        from chatlog_keeper.macos_debug_app import launch_debug_copy
+        from chatlog_keeper.macos_key import extract_verified
+        resolved = Path(db_path) if db_path else None
+        if not resolved or not resolved.is_file():
+            return None
+        debug_pid = launch_debug_copy("wechat")
+        if not debug_pid:
+            # See the QQ branch above: no fallback to the SIP-protected daily
+            # app when the isolated debug copy did not remain alive.
+            return None
+        # A first-login checkpoint can replace page 1 while the helper scans.
+        # Verify against a stable page before the scan and re-read it after the
+        # candidate is found. Retry once if the DB family changed in between;
+        # never cache a candidate tied only to a stale page.
+        for _attempt in range(2):
+            db_page1 = wechat_db._read_stable_page1(resolved)
+            if not db_page1:
+                continue
+            key = extract_verified(
+                "wechat", debug_pid,
+                lambda candidate: wechat_db._verify_key_v4(candidate, db_page1),
+                elevate=True, timeout=timeout,
+            )
+            if not key:
+                return None
+            latest_page1 = wechat_db._read_stable_page1(resolved)
+            if latest_page1 and wechat_db._verify_key_v4(key, latest_page1):
+                return key
+        return None
     if os.name != "nt":
         logger.warning("active WeChat extraction is Windows-only")
         return None

--- a/chatlog_keeper/cli.py
+++ b/chatlog_keeper/cli.py
@@ -24,6 +24,7 @@ import time
 from pathlib import Path
 
 from chatlog_keeper import active_key, qq_db, wechat_db, wechat_image
+from chatlog_keeper.core._secrets import private_binary_writer
 from chatlog_keeper.export import export_html, export_json
 
 
@@ -34,6 +35,14 @@ def _print_json(obj: dict) -> int:
         pass
     print(json.dumps(obj, ensure_ascii=False, indent=2))
     return 0 if obj.get("available", True) and not obj.get("error") else 1
+
+
+def _prepare_output_dir(path: Path) -> None:
+    """Create a new export directory owner-only without altering an existing one."""
+    existed = path.exists()
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if not existed and os.name != "nt":
+        path.chmod(0o700)
 
 
 # ─── QQ ──────────────────────────────────────────────────────────────────────
@@ -81,7 +90,7 @@ def _export_qq(days: int, out_dir: str) -> dict:
     for m in msgs:
         m["is_self"] = bool(self_qq and m.get("sender_qq") == self_qq)
     out = Path(out_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    _prepare_output_dir(out)
     export_json(msgs, out / "qq_messages.json")
     export_html(msgs, out / "qq_messages.html", title="QQ 聊天记录留存", source="qq")
     return {"source": "qq", "available": True, "n_messages": len(msgs), "days": days,
@@ -158,7 +167,7 @@ def _export_wechat(days: int, out_dir: str) -> dict:
         if d.get("content"):
             msgs.append(d)
     out = Path(out_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    _prepare_output_dir(out)
     export_json(msgs, out / "wechat_messages.json")
     export_html(msgs, out / "wechat_messages.html", title="微信聊天记录留存", source="wechat")
     return {"source": "wechat", "available": True, "n_messages": len(msgs), "days": days,
@@ -184,7 +193,7 @@ def _img_ext(b: bytes) -> str:
 def _decrypt_images(src_dir: str, out_dir: str) -> dict:
     src = Path(src_dir)
     out = Path(out_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    _prepare_output_dir(out)
     n_ok = n_fail = 0
     for dat in src.rglob("*.dat"):
         try:
@@ -198,7 +207,8 @@ def _decrypt_images(src_dir: str, out_dir: str) -> dict:
                 jpg = wechat_image.wxgf_to_jpeg(raw)
                 if jpg:
                     raw, ext = jpg, ".jpg"
-            (out / (dat.stem + ext)).write_bytes(raw)
+            with private_binary_writer(out / (dat.stem + ext)) as handle:
+                handle.write(raw)
             n_ok += 1
         except Exception:  # noqa: BLE001
             n_fail += 1
@@ -278,14 +288,38 @@ def _extract_key(source: str, method: str, data_root: str | None = None) -> dict
 
     ``method="passive"`` (default) scans the live client's process memory — low
     ban risk, no debugger; works on older builds, may find nothing on newer
-    WeChat. ``method="active"`` runs the bundled debugger script — higher ban
-    risk (it attaches a debugger), needs Administrator and you logging into the
-    freshly-launched client, but works on the newest builds. Active is opt-in:
-    you accept the higher risk by choosing it explicitly.
+    WeChat. ``method="active"`` runs the platform helper — a debugger
+    breakpoint on Windows or an isolated debug-enabled app copy plus a
+    read-only Mach scan on macOS. It needs administrator authorization and may
+    require logging into the separately-launched client. Active is opt-in.
     """
     force_extract = os.environ.get("CHATLOG_FORCE_EXTRACT", "").strip().lower() in (
         "1", "true", "yes", "on",
     )
+
+    def _active_failure(default: str) -> str:
+        if sys.platform != "darwin":
+            return default
+        try:
+            from chatlog_keeper.macos_key import last_error
+            reason = last_error()
+        except Exception:
+            reason = ""
+        if reason == "authorization_cancelled":
+            return "macOS administrator authorization was cancelled"
+        if reason == "authorization_interaction_unavailable":
+            return (
+                "macOS could not show the administrator authorization prompt in this "
+                "session; run the command from the logged-in Mac desktop"
+            )
+        if reason == "process_access_denied":
+            return (
+                "macOS denied read-only process access even after authorization "
+                "(SIP/hardened-runtime policy); the client was not modified"
+            )
+        if reason:
+            return f"macOS key helper failed: {reason}"
+        return "macOS memory scan produced no DB-verified key candidate"
     if method == "auto":
         # Try passive first (low ban risk); fall back to active (newer builds)
         # ONLY if passive finds nothing. Export stays cache-first and never
@@ -306,8 +340,10 @@ def _extract_key(source: str, method: str, data_root: str | None = None) -> dict
                         "key_len": len(key), "saved_to": str(qq_db._key_cache_path()),
                         "fresh_extraction": True}
             return {"source": "qq", "method": "active", "ok": False,
-                    "error": "active extraction got no key (not logged into the popped-up QQ / "
-                             "UAC declined / unsupported build)"}
+                    "error": _active_failure(
+                        "active extraction got no key (not logged into the popped-up QQ / "
+                        "UAC declined / unsupported build)"
+                    )}
         reader = qq_db.QQDBReader()
         reader.initialize()  # cache → passive (timeout-bounded) → cache fallback
         key_source = getattr(reader, "key_source", None)
@@ -334,8 +370,10 @@ def _extract_key(source: str, method: str, data_root: str | None = None) -> dict
                         "error": "active extraction could not locate message_0.db for HMAC "
                                  "verification (set --data-root to the xwechat_files folder)"}
             return {"source": "wechat", "method": "active", "ok": False,
-                    "error": "active extraction got no key (not logged into the popped-up WeChat / "
-                             "UAC declined / unsupported build)",
+                    "error": _active_failure(
+                        "active extraction got no key (not logged into the popped-up WeChat / "
+                        "UAC declined / unsupported build)"
+                    ),
                     "db_path": db_path}
         if force_extract:
             return {"source": "wechat", "method": "passive", "ok": False,
@@ -386,17 +424,23 @@ def main(argv: list[str] | None = None) -> int:
 
     p_sk = sub.add_parser("set-key", help="manually supply a key when auto-extract can't get it")
     p_sk.add_argument("--source", choices=["qq", "wechat"], required=True)
-    p_sk.add_argument("--key", type=str, required=True,
-                      help="QQ: 16/32-char passphrase; WeChat: 64-hex master key")
+    key_input = p_sk.add_mutually_exclusive_group(required=True)
+    key_input.add_argument("--key", type=str,
+                           help="QQ: 16/32-char passphrase; WeChat: 64-hex master key")
+    key_input.add_argument(
+        "--key-stdin",
+        action="store_true",
+        help="read the key from standard input so it is not exposed in the process list",
+    )
 
     p_ek = sub.add_parser("extract-key",
                           help="acquire + cache a decryption key automatically")
     p_ek.add_argument("--source", choices=["qq", "wechat"], required=True)
     p_ek.add_argument("--method", choices=["auto", "passive", "active"], default="auto",
                       help="auto (default): passive first, fall back to active only if "
-                           "passive finds nothing. passive: scan live process memory - low "
-                           "ban risk, older builds. active: bundled debugger breakpoint - "
-                           "higher ban risk, needs Administrator + login, newest builds.")
+                           "passive finds nothing. passive: read-only scan of the running "
+                           "client. active: Windows debugger or isolated macOS debug copy; "
+                           "needs administrator authorization and may need a separate login.")
     p_ek.add_argument("--data-root", type=str, default=None,
                       help="override the data folder (else auto-detected)")
 
@@ -419,7 +463,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "images":
         return _print_json(_decrypt_images(args.src, args.out))
     if args.cmd == "set-key":
-        return _print_json(_set_key(args.source, args.key))
+        supplied = sys.stdin.read() if args.key_stdin else args.key
+        return _print_json(_set_key(args.source, supplied))
     if args.cmd == "extract-key":
         return _print_json(_extract_key(args.source, args.method, data_root=getattr(args, "data_root", None)))
     return 2

--- a/chatlog_keeper/core/_macos.py
+++ b/chatlog_keeper/core/_macos.py
@@ -1,0 +1,112 @@
+"""Small, read-only macOS platform helpers.
+
+Keep client discovery separate from the database/crypto code: the latter is
+portable, while process names and sandbox container layouts are not.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def process_pids(app_executables: Iterable[str]) -> List[int]:
+    """Return oldest-first PIDs whose executable path matches an app binary.
+
+    ``ps`` is available on every supported macOS release.  Matching is limited
+    to ``.app/Contents/MacOS/<name>`` so similarly named helper commands do not
+    make ``probe`` report a false positive.
+    """
+    if not is_macos():
+        return []
+    wanted = tuple(f".app/Contents/MacOS/{name}" for name in app_executables)
+    try:
+        proc = subprocess.run(
+            ["ps", "-axo", "pid=,comm="],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+    found: List[int] = []
+    for line in proc.stdout.splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) != 2 or not any(
+            parts[1].endswith(marker) for marker in wanted
+        ):
+            continue
+        try:
+            found.append(int(parts[0]))
+        except ValueError:
+            continue
+    return sorted(set(found))
+
+
+def process_pids_for_executable(executable: Path) -> List[int]:
+    """Return PIDs whose command starts with one exact app executable path."""
+    if not is_macos():
+        return []
+    try:
+        proc = subprocess.run(
+            ["ps", "-axo", "pid=,comm="],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    expected = str(executable)
+    found: List[int] = []
+    for line in proc.stdout.splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) != 2:
+            continue
+        command = parts[1]
+        if command != expected:
+            continue
+        try:
+            found.append(int(parts[0]))
+        except ValueError:
+            continue
+    return sorted(set(found))
+
+
+def wechat_data_roots(home: Path | None = None) -> List[Path]:
+    """Known sandbox roots for Tencent's direct-download macOS WeChat."""
+    home = home or Path.home()
+    return [
+        home
+        / "Library"
+        / "Containers"
+        / "com.tencent.xinWeChat"
+        / "Data"
+        / "Documents"
+        / "xwechat_files",
+        home
+        / "Library"
+        / "Group Containers"
+        / "5A4RE8SF68.com.tencent.xinWeChat"
+        / "xwechat_files",
+    ]
+
+
+def qq_container_roots(home: Path | None = None) -> List[Path]:
+    """Bounded macOS QQ sandbox roots; DB layout is fingerprinted separately."""
+    home = home or Path.home()
+    return [
+        home / "Library" / "Containers" / "com.tencent.qq" / "Data",
+        home / "Library" / "Group Containers" / "FN2V63AD2J.com.tencent",
+    ]

--- a/chatlog_keeper/core/_secrets.py
+++ b/chatlog_keeper/core/_secrets.py
@@ -1,0 +1,80 @@
+"""Local secret-file writes with atomic replacement and restrictive modes."""
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO, IO, Iterator, TextIO, cast
+
+
+@contextmanager
+def _private_writer(
+    path: Path, *, binary: bool, secure_parent: bool
+) -> Iterator[IO]:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if secure_parent and os.name != "nt":
+        path.parent.chmod(0o700)
+
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, 0o600)
+        if binary:
+            handle = os.fdopen(fd, "wb")
+        else:
+            handle = os.fdopen(fd, "w", encoding="utf-8", newline="\n")
+        fd = -1
+        with handle:
+            yield handle
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        if os.name != "nt":
+            path.chmod(0o600)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+@contextmanager
+def private_text_writer(
+    path: Path, *, secure_parent: bool = False
+) -> Iterator[TextIO]:
+    """Yield an atomic UTF-8 writer whose published file is owner-only.
+
+    ``mkstemp`` prevents a symlink race and starts private on POSIX.  The
+    explicit chmods make the guarantee independent of the caller's umask.
+    Existing output directories are left alone unless ``secure_parent`` is
+    requested for a secret cache directory.
+    """
+    with _private_writer(
+        path, binary=False, secure_parent=secure_parent
+    ) as handle:
+        yield cast(TextIO, handle)
+
+
+@contextmanager
+def private_binary_writer(
+    path: Path, *, secure_parent: bool = False
+) -> Iterator[BinaryIO]:
+    """Binary counterpart to :func:`private_text_writer`."""
+    with _private_writer(
+        path, binary=True, secure_parent=secure_parent
+    ) as handle:
+        yield cast(BinaryIO, handle)
+
+
+def write_secret_text(path: Path, text: str) -> bool:
+    try:
+        with private_text_writer(path, secure_parent=True) as handle:
+            handle.write(text)
+        return True
+    except OSError:
+        return False

--- a/chatlog_keeper/core/_snapshot.py
+++ b/chatlog_keeper/core/_snapshot.py
@@ -1,0 +1,132 @@
+"""Consistent private snapshots of a SQLite/SQLCipher DB family."""
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+_SIDECAR_SUFFIXES = ("-wal", "-shm")
+_MAX_SNAPSHOT_ATTEMPTS = 3
+
+
+def _copy_file(source: Path, destination: Path) -> None:
+    # APFS clone-copy is effectively immediate and avoids reading a changing
+    # multi-GB DB through Python. Fall back for non-APFS filesystems/platforms.
+    if sys.platform == "darwin":
+        proc = subprocess.run(
+            ["/bin/cp", "-c", "-p", str(source), str(destination)],
+            capture_output=True,
+            timeout=60,
+            check=False,
+        )
+        if proc.returncode == 0:
+            return
+    shutil.copy2(source, destination)
+
+
+def _file_fingerprint(path: Path, size: int) -> str:
+    """Hash bounded edge content so mmap/in-place sidecar writes are visible."""
+    digest = hashlib.blake2b(digest_size=16)
+    with path.open("rb") as handle:
+        digest.update(handle.read(4096))
+        if size > 4096:
+            handle.seek(max(4096, size - 4096))
+            digest.update(handle.read(4096))
+    return digest.hexdigest()
+
+
+def _family_signature(
+    db_path: Path,
+) -> tuple[tuple[str, bool, int, int, str], ...]:
+    """Detect both metadata changes and in-place WAL-index generation changes."""
+    signature = []
+    for suffix in ("", *_SIDECAR_SUFFIXES):
+        path = db_path if not suffix else db_path.with_name(db_path.name + suffix)
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            signature.append((suffix, False, 0, 0, ""))
+        else:
+            try:
+                fingerprint = _file_fingerprint(path, stat.st_size)
+            except FileNotFoundError:
+                signature.append((suffix, False, 0, 0, ""))
+            else:
+                signature.append(
+                    (suffix, True, stat.st_size, stat.st_mtime_ns, fingerprint)
+                )
+    return tuple(signature)
+
+
+def read_stable_prefix(db_path: Path, size: int) -> bytes:
+    """Read a DB prefix only when the live DB family stays unchanged.
+
+    Key HMAC verification only needs page 1. Cloning a multi-GB database merely
+    to read 4 KiB is wasteful on non-APFS storage, but a plain read can race a
+    WAL checkpoint or DB replacement. Comparing the main/WAL/SHM signature
+    around the bounded read gives the verifier the same fail-closed stability
+    guarantee without copying the family.
+    """
+    db_path = Path(db_path)
+    if size <= 0:
+        raise ValueError("size must be positive")
+    for _attempt in range(_MAX_SNAPSHOT_ATTEMPTS):
+        before = _family_signature(db_path)
+        if not before[0][1]:
+            raise FileNotFoundError(db_path)
+        try:
+            with db_path.open("rb") as handle:
+                value = handle.read(size)
+        except FileNotFoundError:
+            continue
+        if len(value) == size and before == _family_signature(db_path):
+            return value
+    raise OSError(
+        f"database remained active during {_MAX_SNAPSHOT_ATTEMPTS} prefix reads: "
+        f"{db_path.name}"
+    )
+
+
+@contextmanager
+def snapshot_db_family(db_path: Path) -> Iterator[Path]:
+    """Yield a stable private DB copy with any ``-wal``/``-shm`` siblings.
+
+    SQLCipher cannot be opened through Python's SQLite backup API before it is
+    decrypted. We therefore clone the file family and require its size/mtime
+    signature to be unchanged across the copy. A busy writer gets three fast
+    retries instead of silently producing a main-DB/WAL mixture from different
+    moments.
+    """
+    db_path = Path(db_path)
+    with tempfile.TemporaryDirectory(prefix="chatlog_db_snapshot_") as tmp:
+        root = Path(tmp)
+        snap = root / db_path.name
+        for _attempt in range(_MAX_SNAPSHOT_ATTEMPTS):
+            before = _family_signature(db_path)
+            if not before[0][1]:
+                raise FileNotFoundError(db_path)
+            for suffix in ("", *_SIDECAR_SUFFIXES):
+                destination = (
+                    snap if not suffix else snap.with_name(snap.name + suffix)
+                )
+                destination.unlink(missing_ok=True)
+            try:
+                _copy_file(db_path, snap)
+                for suffix in _SIDECAR_SUFFIXES:
+                    sidecar = db_path.with_name(db_path.name + suffix)
+                    if sidecar.is_file():
+                        _copy_file(sidecar, snap.with_name(snap.name + suffix))
+            except FileNotFoundError:
+                continue
+            if before == _family_signature(db_path):
+                yield snap
+                return
+        raise OSError(
+            f"database remained active during {_MAX_SNAPSHOT_ATTEMPTS} snapshot attempts: "
+            f"{db_path.name}"
+        )

--- a/chatlog_keeper/core/_wal.py
+++ b/chatlog_keeper/core/_wal.py
@@ -1,0 +1,289 @@
+"""Validated SQLite WAL recovery for decrypted SQLCipher snapshots.
+
+SQLite authenticates the structural WAL stream with cumulative checksums and
+salt values.  SQLCipher independently authenticates each encrypted page image.
+Callers provide the page decrypt/HMAC oracle; this module validates SQLite's
+own WAL and WAL-index contracts before any plaintext database is mutated.
+"""
+from __future__ import annotations
+
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+_WAL_MAGIC_LITTLE_CHECKSUM = 0x377F0682
+_WAL_MAGIC_BIG_CHECKSUM = 0x377F0683
+_WAL_VERSION = 3007000
+
+
+class WalValidationError(OSError):
+    """The WAL family cannot be proven structurally consistent."""
+
+
+@dataclass(frozen=True)
+class WalPlan:
+    present: bool
+    page_size: int
+    frames_to_apply: int
+    commit_size: int
+    valid_frames: int
+    physical_frames: int
+    used_shm: bool
+    file_signature: tuple[int, int, int, int]
+
+
+@dataclass(frozen=True)
+class _ShmState:
+    mx_frame: int
+    n_page: int
+    frame_checksum: tuple[int, int]
+
+
+def _checksum_bytes(
+    data: bytes,
+    checksum: tuple[int, int] = (0, 0),
+    *,
+    big_endian: bool,
+) -> tuple[int, int]:
+    if len(data) % 8:
+        raise WalValidationError("WAL checksum input is not 8-byte aligned")
+    endian = ">" if big_endian else "<"
+    values = struct.unpack(f"{endian}{len(data) // 4}I", data)
+    s0, s1 = checksum
+    for index in range(0, len(values), 2):
+        s0 = (s0 + values[index] + s1) & 0xFFFFFFFF
+        s1 = (s1 + values[index + 1] + s0) & 0xFFFFFFFF
+    return s0, s1
+
+
+def _read_shm_state(
+    shm_path: Path,
+    *,
+    wal_header: bytes,
+    magic: int,
+    page_size: int,
+) -> Optional[_ShmState]:
+    if not shm_path.is_file():
+        return None
+    try:
+        with shm_path.open("rb") as handle:
+            raw = handle.read(96)
+    except OSError as exc:
+        raise WalValidationError(f"cannot read WAL index: {type(exc).__name__}") from exc
+    if len(raw) < 96:
+        raise WalValidationError("WAL index header is truncated")
+    first, second = raw[:48], raw[48:96]
+    if first != second:
+        raise WalValidationError("WAL index header copies disagree")
+
+    native = "<" if sys.byteorder == "little" else ">"
+    version = struct.unpack_from(f"{native}I", first, 0)[0]
+    is_init = first[12]
+    big_end_checksum = first[13]
+    encoded_page_size = struct.unpack_from(f"{native}H", first, 14)[0]
+    index_page_size = 65536 if encoded_page_size == 1 else encoded_page_size
+    mx_frame, n_page = struct.unpack_from(f"{native}II", first, 16)
+    frame_checksum = struct.unpack_from(f"{native}II", first, 24)
+    stored_checksum = struct.unpack_from(f"{native}II", first, 40)
+    computed_checksum = _checksum_bytes(
+        first[:40],
+        big_endian=(sys.byteorder == "big"),
+    )
+
+    if version != _WAL_VERSION or first[4:8] != b"\0\0\0\0":
+        raise WalValidationError("unsupported WAL index version")
+    if is_init not in (0, 1):
+        raise WalValidationError("invalid WAL index initialization flag")
+    if index_page_size != page_size:
+        raise WalValidationError("WAL index page size mismatch")
+    expected_big = int(magic == _WAL_MAGIC_BIG_CHECKSUM)
+    if big_end_checksum != expected_big:
+        raise WalValidationError("WAL index checksum byte order mismatch")
+    if first[32:40] != wal_header[16:24]:
+        raise WalValidationError("WAL index salt mismatch")
+    if computed_checksum != stored_checksum:
+        raise WalValidationError("WAL index header checksum mismatch")
+    if not is_init:
+        if mx_frame != 0:
+            raise WalValidationError("uninitialized WAL index has committed frames")
+        return _ShmState(0, 0, (0, 0))
+    return _ShmState(mx_frame, n_page, frame_checksum)
+
+
+def inspect_wal(
+    wal_path: Path,
+    *,
+    shm_path: Optional[Path] = None,
+    expected_page_size: Optional[int] = None,
+) -> WalPlan:
+    """Validate a WAL snapshot and return the committed recovery boundary.
+
+    When a copied ``-shm`` file is available, its two checksummed headers and
+    ``mxFrame`` are authoritative.  Without ``-shm`` we mirror SQLite recovery:
+    scan checksum-valid frames until the first stale/invalid tail and use the
+    last complete commit marker.
+    """
+    wal_path = Path(wal_path)
+    try:
+        stat = wal_path.stat()
+    except FileNotFoundError:
+        return WalPlan(False, expected_page_size or 0, 0, 0, 0, 0, False, (0, 0, 0, 0))
+    signature = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+    if stat.st_size == 0:
+        return WalPlan(True, expected_page_size or 0, 0, 0, 0, 0, False, signature)
+    if stat.st_size < 32:
+        raise WalValidationError("WAL header is truncated")
+
+    with wal_path.open("rb") as wal:
+        header = wal.read(32)
+        try:
+            magic, version, encoded_page_size = struct.unpack(">III", header[:12])
+        except struct.error as exc:
+            raise WalValidationError("WAL header is malformed") from exc
+        if magic not in (_WAL_MAGIC_LITTLE_CHECKSUM, _WAL_MAGIC_BIG_CHECKSUM):
+            raise WalValidationError("WAL magic is invalid")
+        if version != _WAL_VERSION:
+            raise WalValidationError("unsupported WAL version")
+        page_size = 65536 if encoded_page_size in (0, 1) else encoded_page_size
+        if expected_page_size is not None and page_size != expected_page_size:
+            raise WalValidationError("WAL page size is unsupported")
+        big_endian = magic == _WAL_MAGIC_BIG_CHECKSUM
+        stored_header_checksum = struct.unpack(">II", header[24:32])
+        checksum = _checksum_bytes(header[:24], big_endian=big_endian)
+        if checksum != stored_header_checksum:
+            raise WalValidationError("WAL header checksum mismatch")
+
+        frame_size = 24 + page_size
+        physical_frames = max(0, (stat.st_size - 32) // frame_size)
+        resolved_shm = shm_path or wal_path.with_name(
+            wal_path.name[:-4] + "-shm"
+            if wal_path.name.endswith("-wal")
+            else wal_path.name + "-shm"
+        )
+        shm = _read_shm_state(
+            Path(resolved_shm),
+            wal_header=header,
+            magic=magic,
+            page_size=page_size,
+        )
+        scan_limit = shm.mx_frame if shm is not None else physical_frames
+        if scan_limit > physical_frames:
+            raise WalValidationError("WAL index references missing frames")
+
+        salt = header[16:24]
+        valid_frames = 0
+        last_commit = 0
+        commit_size = 0
+        last_frame_checksum = stored_header_checksum
+        for index in range(scan_limit):
+            frame_header = wal.read(24)
+            page = wal.read(page_size)
+            if len(frame_header) != 24 or len(page) != page_size:
+                if shm is not None:
+                    raise WalValidationError("committed WAL frame is truncated")
+                break
+            page_no, db_size = struct.unpack(">II", frame_header[:8])
+            if page_no <= 0 or frame_header[8:16] != salt:
+                if shm is not None:
+                    raise WalValidationError("committed WAL frame salt/page is invalid")
+                break
+            checksum = _checksum_bytes(
+                frame_header[:8] + page,
+                checksum,
+                big_endian=big_endian,
+            )
+            stored_frame_checksum = struct.unpack(">II", frame_header[16:24])
+            if checksum != stored_frame_checksum:
+                if shm is not None:
+                    raise WalValidationError("committed WAL frame checksum mismatch")
+                break
+            valid_frames += 1
+            last_frame_checksum = stored_frame_checksum
+            if db_size:
+                last_commit = index + 1
+                commit_size = db_size
+
+        if shm is not None:
+            if valid_frames != shm.mx_frame:
+                raise WalValidationError("WAL index committed-frame count mismatch")
+            if shm.mx_frame:
+                if last_commit != shm.mx_frame or commit_size != shm.n_page:
+                    raise WalValidationError("WAL index does not end at a commit frame")
+                if last_frame_checksum != shm.frame_checksum:
+                    raise WalValidationError("WAL index frame checksum mismatch")
+            else:
+                last_commit = 0
+                commit_size = 0
+
+    return WalPlan(
+        True,
+        page_size,
+        last_commit,
+        commit_size,
+        valid_frames,
+        physical_frames,
+        shm is not None,
+        signature,
+    )
+
+
+def apply_wal(
+    wal_path: Path,
+    output_path: Path,
+    decrypt_page: Callable[[bytes, int], Optional[bytes]],
+    *,
+    shm_path: Optional[Path] = None,
+    expected_page_size: Optional[int] = None,
+) -> int:
+    """Validate/decrypt committed frames, then atomically mutate the temp DB.
+
+    Every SQLCipher page is authenticated in a full first pass.  Only after all
+    committed pages pass does a second pass write them to the already-private
+    plaintext output.  The WAL snapshot identity must remain unchanged across
+    both passes.
+    """
+    wal_path = Path(wal_path)
+    plan = inspect_wal(
+        wal_path,
+        shm_path=shm_path,
+        expected_page_size=expected_page_size,
+    )
+    if not plan.present or plan.frames_to_apply == 0:
+        return 0
+
+    def iter_committed():
+        with wal_path.open("rb") as wal:
+            wal.seek(32)
+            for _index in range(plan.frames_to_apply):
+                frame_header = wal.read(24)
+                page = wal.read(plan.page_size)
+                if len(frame_header) != 24 or len(page) != plan.page_size:
+                    raise WalValidationError("WAL changed during page recovery")
+                page_no = struct.unpack(">I", frame_header[:4])[0]
+                yield page_no, page
+
+    # Pass 1: SQLCipher HMAC/decrypt validation, without output mutation.
+    for page_no, page in iter_committed():
+        plain = decrypt_page(page, page_no)
+        if plain is None or len(plain) != plan.page_size:
+            raise WalValidationError("SQLCipher WAL page authentication failed")
+
+    # Pass 2: deterministic application through the exact commit boundary.
+    applied = 0
+    with Path(output_path).open("r+b") as output:
+        for page_no, page in iter_committed():
+            plain = decrypt_page(page, page_no)
+            if plain is None or len(plain) != plan.page_size:
+                raise WalValidationError("SQLCipher WAL changed after validation")
+            output.seek((page_no - 1) * plan.page_size)
+            output.write(plain)
+            applied += 1
+        output.truncate(plan.commit_size * plan.page_size)
+
+    stat = wal_path.stat()
+    final_signature = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+    if final_signature != plan.file_signature:
+        raise WalValidationError("WAL snapshot changed during recovery")
+    return applied

--- a/chatlog_keeper/export.py
+++ b/chatlog_keeper/export.py
@@ -18,6 +18,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
+from .core._secrets import private_text_writer
+
 __all__ = ["export_json", "export_html"]
 
 
@@ -57,8 +59,7 @@ def _is_self(m: Dict[str, Any]) -> bool:
 def export_json(messages: List[Dict[str, Any]], path) -> int:
     """Write the raw message list to ``path`` as pretty UTF-8 JSON. Returns count."""
     p = Path(path)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    with open(p, "w", encoding="utf-8") as f:
+    with private_text_writer(p) as f:
         json.dump(messages, f, ensure_ascii=False, indent=2)
     return len(messages)
 
@@ -123,8 +124,6 @@ def export_html(messages: List[Dict[str, Any]], path, *,
     separators. Your own messages sit on the right (green bubble), like the app.
     """
     p = Path(path)
-    p.parent.mkdir(parents=True, exist_ok=True)
-
     # group by conversation, each ordered by time
     chats: Dict[str, List[Dict[str, Any]]] = {}
     for m in messages:
@@ -176,6 +175,6 @@ def export_html(messages: List[Dict[str, Any]], path, *,
                  "Generated locally by chatlog-keeper — nothing was ever uploaded.</footer>")
     parts.append("</div></body></html>")
 
-    with open(p, "w", encoding="utf-8") as f:
+    with private_text_writer(p) as f:
         f.write("".join(parts))
     return len(messages)

--- a/chatlog_keeper/macos_debug_app.py
+++ b/chatlog_keeper/macos_debug_app.py
@@ -1,0 +1,251 @@
+"""Create an isolated, reversible debug-enabled copy of a macOS chat client.
+
+The signed app in ``/Applications`` is never modified.  Explicit ``active``
+extraction may launch this private copy so Apple's task-port policy can be met
+without disabling SIP or weakening the user's daily client.
+"""
+from __future__ import annotations
+
+import hashlib
+import plistlib
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+from chatlog_keeper.core._path_resolver import data_dir
+
+_APPS = {
+    "wechat": (Path("/Applications/WeChat.app"), "WeChat"),
+    "qq": (Path("/Applications/QQ.app"), "QQ"),
+}
+_DEBUG_COPY_FORMAT = (
+    b"preserve-nested-signatures-v4-executable-provenance-marker"
+)
+
+
+def _run(argv: list[str], timeout: int = 300) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _app_identity(app: Path) -> str:
+    info = (app / "Contents" / "Info.plist").read_bytes()
+    try:
+        metadata = plistlib.loads(info)
+    except Exception as exc:
+        raise OSError("app bundle has an invalid Info.plist") from exc
+    executable_name = metadata.get("CFBundleExecutable")
+    if not isinstance(executable_name, str) or not executable_name:
+        raise OSError("app bundle has no CFBundleExecutable")
+    executable = app / "Contents" / "MacOS" / executable_name
+    digest = hashlib.sha256()
+    digest.update(info)
+    with executable.open("rb") as handle:
+        while True:
+            chunk = handle.read(1 << 20)
+            if not chunk:
+                break
+            digest.update(chunk)
+    digest.update(b"\0chatlog-keeper-debug-copy\0")
+    digest.update(_DEBUG_COPY_FORMAT)
+    return digest.hexdigest()[:12]
+
+
+def _entitlements(app: Path) -> Optional[dict]:
+    proc = _run(["codesign", "-d", "--entitlements", ":-", str(app)], timeout=30)
+    raw = (proc.stdout or proc.stderr).encode("utf-8", errors="replace")
+    start = raw.find(b"<?xml")
+    if start < 0:
+        return None
+    try:
+        value = plistlib.loads(raw[start:])
+    except Exception:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _verified_debug_copy(
+    target: Path,
+    marker: Path,
+    expected_identity: str,
+) -> bool:
+    if not marker.is_file():
+        return False
+    try:
+        if marker.read_text(encoding="ascii").strip() != expected_identity:
+            return False
+    except (OSError, UnicodeError):
+        return False
+    current = _entitlements(target) or {}
+    verified = _run(
+        ["codesign", "--verify", "--deep", "--strict", str(target)], timeout=60
+    )
+    return (
+        verified.returncode == 0
+        and current.get("com.apple.security.get-task-allow") is True
+    )
+
+
+def prepare_debug_copy(source: str) -> Optional[Path]:
+    """Return a verified debug-enabled app copy, or ``None`` on failure."""
+    if sys.platform != "darwin" or source not in _APPS:
+        return None
+    original, _ = _APPS[source]
+    if not original.is_dir():
+        return None
+    try:
+        identity = _app_identity(original)
+    except OSError:
+        return None
+
+    root = data_dir() / "debug-apps"
+    target = root / f"{original.stem}-{identity}.app"
+    marker = (
+        target
+        / "Contents"
+        / "Resources"
+        / ".chatlog-keeper-debug-copy"
+    )
+    if marker.is_file():
+        if _verified_debug_copy(target, marker, identity):
+            return target
+        return None
+
+    root.mkdir(parents=True, exist_ok=True)
+    root.chmod(0o700)
+    if target.exists():
+        # A partial or foreign directory is never overwritten automatically.
+        return None
+    # Build and sign in a private staging directory. A failed ditto/codesign is
+    # removed automatically and can be retried; the canonical target appears
+    # only after every verification gate passes.
+    with tempfile.TemporaryDirectory(
+        prefix=f".{original.stem}-{identity}-", dir=str(root)
+    ) as temporary:
+        stage_root = Path(temporary)
+        stage = stage_root / target.name
+        copied = _run(["/usr/bin/ditto", str(original), str(stage)], timeout=600)
+        if copied.returncode != 0:
+            return None
+
+        entitlements = _entitlements(original)
+        if entitlements is None:
+            return None
+        entitlements["com.apple.security.get-task-allow"] = True
+        ent_path = stage_root / "entitlements.plist"
+        ent_path.write_bytes(plistlib.dumps(entitlements, fmt=plistlib.FMT_XML))
+        stage_marker = (
+            stage
+            / "Contents"
+            / "Resources"
+            / ".chatlog-keeper-debug-copy"
+        )
+        # The provenance marker is covered by the final bundle resource seal.
+        stage_marker.parent.mkdir(parents=True, exist_ok=True)
+        stage_marker.write_text(identity, encoding="ascii")
+
+        signed = _run(
+            [
+                "codesign",
+                "--force",
+                "--sign",
+                "-",
+                "--entitlements",
+                str(ent_path),
+                str(stage),
+            ],
+            timeout=600,
+        )
+        if signed.returncode != 0 or not _verified_debug_copy(
+            stage, stage_marker, identity
+        ):
+            return None
+        try:
+            stage.replace(target)
+        except OSError:
+            # Another process may have won the same deterministic directory
+            # rename race.  macOS can report this as ENOTEMPTY/EEXIST rather
+            # than Python's FileExistsError.  Only accept the winner after the
+            # complete signature + entitlement + marker verification gate;
+            # every other rename error still fails closed.
+            return (
+                target
+                if _verified_debug_copy(target, marker, identity)
+                else None
+            )
+    return (
+        target if _verified_debug_copy(target, marker, identity) else None
+    )
+
+
+def _wait_for_stable_pid(
+    executable: Path,
+    *,
+    wait_s: float,
+    settle_s: float,
+) -> Optional[int]:
+    """Return an exact executable PID only after it survives ``settle_s``."""
+    from chatlog_keeper.core._macos import process_pids_for_executable
+
+    wait_s = max(0.0, wait_s)
+    settle_s = min(max(0.0, settle_s), wait_s)
+    deadline = time.monotonic() + wait_s
+    first_seen: dict[int, float] = {}
+    while True:
+        now = time.monotonic()
+        current = set(process_pids_for_executable(executable))
+        for pid in tuple(first_seen):
+            if pid not in current:
+                del first_seen[pid]
+        for pid in sorted(current):
+            first_seen.setdefault(pid, now)
+            if now - first_seen[pid] >= settle_s:
+                return pid
+        if now >= deadline:
+            return None
+        time.sleep(min(0.25, max(0.0, deadline - now)))
+
+
+def launch_debug_copy(
+    source: str,
+    wait_s: float = 15.0,
+    settle_s: float = 5.0,
+) -> Optional[int]:
+    """Launch the isolated copy and return a stable, exact main PID.
+
+    Current WeChat/QQ builds can briefly create a process and then exit when a
+    signed daily client already owns the single-instance lock.  A transient
+    PID must never be handed to ``task_for_pid``: it produces a misleading SIP
+    denial and an unnecessary administrator prompt.
+    """
+    target = prepare_debug_copy(source)
+    if not target:
+        return None
+    executable = target / "Contents" / "MacOS" / _APPS[source][1]
+
+    from chatlog_keeper.core._macos import process_pids_for_executable
+    if process_pids_for_executable(executable):
+        existing = _wait_for_stable_pid(
+            executable,
+            wait_s=min(wait_s, max(settle_s, 0.0)),
+            settle_s=settle_s,
+        )
+        if existing:
+            return existing
+
+    launched = _run(["/usr/bin/open", "-n", str(target)], timeout=30)
+    if launched.returncode != 0:
+        return None
+    return _wait_for_stable_pid(
+        executable,
+        wait_s=wait_s,
+        settle_s=settle_s,
+    )

--- a/chatlog_keeper/macos_key.py
+++ b/chatlog_keeper/macos_key.py
@@ -1,0 +1,317 @@
+"""macOS key-candidate acquisition using a bundled, read-only Mach helper."""
+from __future__ import annotations
+
+from collections import Counter
+import hashlib
+import os
+import plistlib
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from chatlog_keeper.core._path_resolver import data_dir
+
+_LAST_ERROR = ""
+_DEBUGGER_ENTITLEMENTS = {"com.apple.security.cs.debugger": True}
+
+
+def _source_path() -> Path:
+    return Path(__file__).resolve().parent / "scripts" / "macos_memory_scan.c"
+
+
+def _prebuilt_path() -> Path:
+    return Path(__file__).resolve().parent / "scripts" / "macos_memory_scan"
+
+
+def _helper_input_path() -> Path:
+    prebuilt = _prebuilt_path()
+    return prebuilt if prebuilt.is_file() else _source_path()
+
+
+def _debugger_entitlements_bytes() -> bytes:
+    return plistlib.dumps(_DEBUGGER_ENTITLEMENTS, fmt=plistlib.FMT_XML)
+
+
+def _helper_path() -> Path:
+    digest = hashlib.sha256()
+    digest.update(_helper_input_path().read_bytes())
+    digest.update(b"\0chatlog-keeper-debugger-entitlements\0")
+    digest.update(_debugger_entitlements_bytes())
+    short_digest = digest.hexdigest()[:12]
+    return data_dir() / "bin" / f"macos-memory-scan-{short_digest}"
+
+
+def _has_debugger_entitlement(helper: Path) -> bool:
+    verified = subprocess.run(
+        ["codesign", "--verify", "--strict", str(helper)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if verified.returncode != 0:
+        return False
+    described = subprocess.run(
+        ["codesign", "-d", "--entitlements", ":-", str(helper)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    raw = (described.stdout or "") + "\n" + (described.stderr or "")
+    start = raw.find("<?xml")
+    end = raw.find("</plist>", start)
+    if start < 0 or end < 0:
+        return False
+    try:
+        entitlements = plistlib.loads(raw[start:end + len("</plist>")].encode("utf-8"))
+    except Exception:
+        return False
+    return (
+        described.returncode == 0
+        and isinstance(entitlements, dict)
+        and entitlements.get("com.apple.security.cs.debugger") is True
+    )
+
+
+def ensure_helper() -> Optional[Path]:
+    """Compile and ad-hoc sign our own helper; never modifies chat clients."""
+    global _LAST_ERROR
+    if sys.platform != "darwin":
+        return None
+    source = _source_path()
+    prebuilt = _prebuilt_path()
+    if not source.is_file() and not prebuilt.is_file():
+        _LAST_ERROR = "helper_source_missing"
+        return None
+    helper = _helper_path()
+    if helper.is_file() and os.access(helper, os.X_OK):
+        try:
+            if _has_debugger_entitlement(helper):
+                return helper
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    helper.parent.mkdir(parents=True, exist_ok=True)
+    helper.parent.chmod(0o700)
+    temporary = helper.with_name(f".{helper.name}.{os.getpid()}.tmp")
+    entitlements = helper.with_name(
+        f".{helper.name}.{os.getpid()}.entitlements.plist"
+    )
+    try:
+        if prebuilt.is_file():
+            shutil.copy2(prebuilt, temporary)
+        else:
+            proc = subprocess.run(
+                [
+                    "xcrun",
+                    "clang",
+                    "-O2",
+                    "-Wall",
+                    "-Wextra",
+                    str(source),
+                    "-o",
+                    str(temporary),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+            if proc.returncode != 0:
+                _LAST_ERROR = "helper_compile_failed"
+                return None
+        temporary.chmod(0o700)
+        entitlements.write_bytes(_debugger_entitlements_bytes())
+        entitlements.chmod(0o600)
+        # Ad-hoc signing makes the helper's code identity explicit. Fail closed:
+        # an unsigned helper, or one lacking Apple's debugger entitlement,
+        # cannot obtain a task port even when the isolated target explicitly
+        # carries get-task-allow.
+        signed = subprocess.run(
+            [
+                "codesign",
+                "--force",
+                "--sign",
+                "-",
+                "--entitlements",
+                str(entitlements),
+                str(temporary),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if signed.returncode != 0:
+            _LAST_ERROR = "helper_codesign_failed"
+            return None
+        if not _has_debugger_entitlement(temporary):
+            _LAST_ERROR = "helper_debugger_entitlement_missing"
+            return None
+        os.replace(temporary, helper)
+        return helper
+    except subprocess.TimeoutExpired:
+        _LAST_ERROR = "helper_build_timeout"
+        return None
+    except OSError as exc:
+        _LAST_ERROR = f"helper_build_failed:{type(exc).__name__}"
+        return None
+    finally:
+        for cleanup in (temporary, entitlements):
+            try:
+                cleanup.unlink()
+            except OSError:
+                pass
+
+
+def _parse_candidates(text: str, marker: str) -> Iterable[bytes]:
+    seen = set()
+    prefix = marker + ":"
+    for line in text.splitlines():
+        if not line.startswith(prefix):
+            continue
+        raw = line[len(prefix):].strip()
+        try:
+            value = bytes.fromhex(raw)
+        except ValueError:
+            continue
+        if value not in seen:
+            seen.add(value)
+            yield value
+
+
+def _rank_candidates(text: str, marker: str, expected: tuple[int, ...]) -> list[bytes]:
+    """Return unique candidates in a source-appropriate verification order.
+
+    The Mach helper emits one line per memory occurrence.  QQ's passphrase is
+    normally present many times, while a large Electron process also contains
+    tens of thousands of unrelated 16/32-byte strings.  Preserve that frequency
+    signal and prefer the current 16-byte QQ format before trying legacy
+    32-byte values.  WeChat keeps helper order because its candidates are
+    already sparse and all have one expected length.
+
+    Candidate bytes remain process-local: this function never logs or formats
+    them for diagnostics.
+    """
+    if marker != "QQ":
+        return [
+            candidate
+            for candidate in _parse_candidates(text, marker)
+            if len(candidate) in expected
+        ]
+
+    counts: Counter[bytes] = Counter()
+    prefix = marker + ":"
+    for line in text.splitlines():
+        if not line.startswith(prefix):
+            continue
+        raw = line[len(prefix):].strip()
+        try:
+            value = bytes.fromhex(raw)
+        except ValueError:
+            continue
+        if len(value) in expected:
+            counts[value] += 1
+    return sorted(
+        counts,
+        key=lambda value: (
+            0 if len(value) == 16 else 1,
+            -counts[value],
+            value,
+        ),
+    )
+
+
+def _run_helper(source: str, pid: int, *, elevate: bool, timeout: int) -> str:
+    global _LAST_ERROR
+    _LAST_ERROR = ""
+    helper = ensure_helper()
+    if not helper:
+        if not _LAST_ERROR:
+            _LAST_ERROR = "helper_unavailable"
+        return ""
+    argv = [str(helper), source, str(int(pid))]
+    if not elevate:
+        try:
+            proc = subprocess.run(
+                argv, capture_output=True, text=True, timeout=timeout, check=False
+            )
+        except subprocess.TimeoutExpired:
+            _LAST_ERROR = "helper_timeout"
+            return ""
+        except OSError as exc:
+            _LAST_ERROR = f"helper_launch_failed:{type(exc).__name__}"
+            return ""
+        if proc.returncode:
+            _LAST_ERROR = (proc.stderr or f"helper_exit_{proc.returncode}").strip()
+            return ""
+        return proc.stdout
+    command = " ".join(shlex.quote(part) for part in argv)
+    # AppleScript string literals use double quotes, unlike Python repr().
+    escaped = command.replace("\\", "\\\\").replace('"', '\\"')
+    script = f'do shell script "{escaped}" with administrator privileges'
+    try:
+        proc = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        _LAST_ERROR = "helper_timeout"
+        return ""
+    except OSError as exc:
+        _LAST_ERROR = f"authorization_launch_failed:{type(exc).__name__}"
+        return ""
+    if proc.returncode:
+        _LAST_ERROR = (proc.stderr or f"osascript_exit_{proc.returncode}").strip()
+        return ""
+    return proc.stdout
+
+
+def last_error() -> str:
+    """Machine-readable diagnostic from the most recent helper invocation."""
+    if "task_for_pid:" in _LAST_ERROR:
+        return "process_access_denied"
+    if "User canceled" in _LAST_ERROR or "-128" in _LAST_ERROR:
+        return "authorization_cancelled"
+    if (
+        "-60007" in _LAST_ERROR
+        or "no user interaction was possible" in _LAST_ERROR.lower()
+    ):
+        return "authorization_interaction_unavailable"
+    return _LAST_ERROR
+
+
+def extract_verified(
+    source: str,
+    pid: int,
+    verify: Callable[[bytes], bool],
+    *,
+    primary_verify: Optional[Callable[[bytes], bool]] = None,
+    elevate: bool = False,
+    timeout: int = 120,
+) -> Optional[bytes]:
+    """Return the first DB-verified candidate; unverified bytes are discarded.
+
+    ``primary_verify`` is an optional fast oracle for the current client
+    format.  A primary match is always confirmed by the full ``verify`` oracle.
+    If the primary pass finds nothing, the full verifier still checks every
+    ranked candidate so older client formats remain supported.
+    """
+    marker = "QQ" if source == "qq" else "WX"
+    text = _run_helper(source, pid, elevate=elevate, timeout=timeout)
+    expected = (16, 32) if source == "qq" else (32,)
+    candidates = _rank_candidates(text, marker, expected)
+    if primary_verify is not None:
+        for candidate in candidates:
+            if primary_verify(candidate) and verify(candidate):
+                return candidate
+    for candidate in candidates:
+        if verify(candidate):
+            return candidate
+    return None

--- a/chatlog_keeper/qq_db.py
+++ b/chatlog_keeper/qq_db.py
@@ -1,4 +1,4 @@
-"""
+r"""
 qq_db.py — QQ NT (QQNT) local message database reader.
 
 Based on wechat_db.py architecture but adapted for QQ NT parameters:
@@ -23,6 +23,7 @@ import os
 import re
 import struct
 import subprocess
+import sys
 import tempfile
 from datetime import datetime, date, timedelta
 from pathlib import Path
@@ -127,6 +128,9 @@ def _rank_qq_pids(pids: List[int]) -> List[int]:
 
 def _get_qq_pids() -> list:
     """Return QQ.exe PIDs with the root client before Chromium helpers."""
+    if sys.platform == "darwin":
+        from chatlog_keeper.core._macos import process_pids
+        return process_pids(("QQ",))
     try:
         r = subprocess.run(
             ["tasklist", "/FO", "CSV", "/FI", "IMAGENAME eq QQ.exe"],
@@ -170,6 +174,10 @@ def find_qq_data_root() -> Optional[Path]:
     env = os.environ.get("CHATLOG_QQ_DATA_ROOT", "").strip()
     if env:
         candidates.append(Path(env))
+    if sys.platform == "darwin":
+        from chatlog_keeper.core._macos import qq_container_roots
+        for container in qq_container_roots():
+            candidates.append(container / "Library" / "Application Support" / "QQ")
     for doc in candidate_documents_roots():
         candidates.append(doc / "Tencent Files")
     for drive in all_drive_roots():
@@ -191,9 +199,13 @@ def find_qq_data_root() -> Optional[Path]:
             if not c.exists():
                 continue
             for sub in c.iterdir():
-                if not (sub.is_dir() and sub.name.isdigit()):
+                if not sub.is_dir():
+                    continue
+                if not sub.name.isdigit() and sys.platform != "darwin":
                     continue
                 db = sub / "nt_qq" / "nt_db" / "nt_msg.db"
+                if not db.exists():
+                    db = sub / "nt_db" / "nt_msg.db"
                 if db.exists() and db.stat().st_size > 0:
                     logger.info(f"Found QQ data root (live): {c} (account={sub.name})")
                     return c
@@ -212,11 +224,21 @@ def find_qq_data_root() -> Optional[Path]:
 
 
 def find_qq_number_dirs(data_root: Path) -> List[Path]:
-    """Return list of QQ number directories inside data_root."""
+    """Return account directories inside data_root.
+
+    Windows names these folders with the numeric QQ account.  Current macOS QQ
+    uses an opaque account directory, so accept a non-numeric directory only
+    when it contains the expected ``nt_db/nt_msg.db`` layout.
+    """
     dirs = []
     try:
         for item in data_root.iterdir():
-            if item.is_dir() and item.name.isdigit():
+            if not item.is_dir():
+                continue
+            if item.name.isdigit() or (
+                sys.platform == "darwin"
+                and (item / "nt_db" / "nt_msg.db").is_file()
+            ):
                 dirs.append(item)
     except OSError as e:
         logger.warning(f"Failed to scan data root: {e}")
@@ -267,7 +289,7 @@ def find_msg_database(data_root: Path) -> Optional[Path]:
 
 # ─── Current-account auto-detection ───────────────────────────────────────────
 
-def detect_current_qq_account() -> Optional[int]:
+def detect_current_qq_account():
     """Detect which QQ account is currently logged in / has live nt_msg.db.
 
     By design, callers must NOT depend on a hardcoded env/CLI value for the
@@ -286,10 +308,10 @@ def detect_current_qq_account() -> Optional[int]:
     root = find_qq_data_root()
     if not root:
         return None
-    best: Optional[Tuple[float, int]] = None
+    best: Optional[Tuple[float, object]] = None
     for qq_dir in find_qq_number_dirs(root):
         try:
-            qid = int(qq_dir.name)
+            qid = int(qq_dir.name) if qq_dir.name.isdigit() else qq_dir.name
         except ValueError:
             continue
         db = qq_dir / "nt_qq" / "nt_db" / "nt_msg.db"
@@ -401,19 +423,12 @@ def save_cached_key(key) -> bool:
     if isinstance(key, str):
         key = key.encode("ascii")
     p = _key_cache_path()
-    try:
-        p.parent.mkdir(parents=True, exist_ok=True)
-        if len(key) in (16, 32) and all(0x20 <= b <= 0x7E for b in key):
-            # ASCII passphrase format (NTQQ 9.9.x)
-            p.write_text(key.decode("ascii"), encoding="utf-8")
-            return True
-        if len(key) == 32:
-            # Legacy raw 32-byte key (hex-encoded)
-            p.write_text(key.hex(), encoding="utf-8")
-            return True
-        return False
-    except OSError:
-        return False
+    from chatlog_keeper.core._secrets import write_secret_text
+    if len(key) in (16, 32) and all(0x20 <= b <= 0x7E for b in key):
+        return write_secret_text(p, key.decode("ascii"))
+    if len(key) == 32:
+        return write_secret_text(p, key.hex())
+    return False
 
 
 # ─── Key extraction from QQ process memory ────────────────────────────────────
@@ -511,6 +526,16 @@ def _verify_key_qq(passphrase, db_raw_or_page1) -> bool:
     return False
 
 
+def _read_qq_verification_bytes(db_path: Path) -> Optional[bytes]:
+    """Read only NTQQ's 1024-byte header plus encrypted 4096-byte page 1."""
+    from chatlog_keeper.core._snapshot import read_stable_prefix
+
+    try:
+        return read_stable_prefix(Path(db_path), 1024 + 4096)
+    except OSError:
+        return None
+
+
 def _is_printable_ascii(b: int) -> bool:
     """0x20..0x7E inclusive, the printable ASCII range."""
     return 0x20 <= b <= 0x7E
@@ -530,6 +555,24 @@ def _scan_memory_for_key(pid: int, db_path: Path = None,
 
     Returns the passphrase as bytes (preserving original ASCII string) or None.
     """
+    if sys.platform == "darwin":
+        if not db_path or not Path(db_path).is_file():
+            return None
+        db_raw = _read_qq_verification_bytes(Path(db_path))
+        if not db_raw:
+            return None
+        from chatlog_keeper.macos_key import extract_verified
+        return extract_verified(
+            "qq",
+            pid,
+            lambda candidate: _verify_key_qq(candidate, db_raw),
+            primary_verify=lambda candidate: _verify_key_qq_with_algo(
+                candidate, db_raw, "sha512", "sha1", 48
+            ),
+            elevate=False,
+            timeout=max(1, int(timeout_s or 120)),
+        )
+
     kernel32 = ctypes.windll.kernel32
     PROCESS_VM_READ = 0x0010
     PROCESS_QUERY_INFORMATION = 0x0400
@@ -541,11 +584,7 @@ def _scan_memory_for_key(pid: int, db_path: Path = None,
 
     db_raw = None
     if db_path and db_path.exists():
-        try:
-            with open(db_path, "rb") as f:
-                db_raw = f.read(1024 + 4096)
-        except Exception:
-            pass
+        db_raw = _read_qq_verification_bytes(Path(db_path))
 
     class MBI64(ctypes.Structure):
         _fields_ = [
@@ -662,19 +701,32 @@ def _skip_header(db_path: Path, output_path: Path) -> bool:
     QQ NT adds a 1024-byte header before the actual SQLCipher data.
     """
     try:
-        # Stream the copy in chunks (skipping the 1024-byte header) to bound memory.
-        with open(db_path, "rb") as f:
-            f.seek(0, 2)
-            if f.tell() < 1024 + 4096:
-                logger.warning(f"File too small: {db_path}")
-                return False
-            f.seek(1024)
-            with open(output_path, "wb") as out:
-                while True:
-                    chunk = f.read(1 << 20)
-                    if not chunk:
-                        break
-                    out.write(chunk)
+        import shutil
+        from chatlog_keeper.core._snapshot import snapshot_db_family
+        with snapshot_db_family(db_path) as snapshot:
+            # Stream the copy in chunks (skipping the 1024-byte header) to bound memory.
+            with open(snapshot, "rb") as f:
+                f.seek(0, 2)
+                if f.tell() < 1024 + 4096:
+                    logger.warning(f"File too small: {db_path}")
+                    return False
+                f.seek(1024)
+                with open(output_path, "wb") as out:
+                    while True:
+                        chunk = f.read(1 << 20)
+                        if not chunk:
+                            break
+                        out.write(chunk)
+            # Preserve the same stable WAL/SHM generation beside the stripped
+            # main DB.  SQLCipher WAL pages do not carry QQ's 1024-byte wrapper
+            # header and are copied verbatim for authenticated recovery after
+            # the main pages are decrypted.
+            for suffix in ("-wal", "-shm"):
+                source = snapshot.with_name(snapshot.name + suffix)
+                destination = output_path.with_name(output_path.name + suffix)
+                destination.unlink(missing_ok=True)
+                if source.is_file():
+                    shutil.copy2(source, destination)
         logger.info(f"Header removed (streaming): {db_path.name} -> {output_path.name}")
         return True
     except Exception as e:
@@ -682,11 +734,73 @@ def _skip_header(db_path: Path, output_path: Path) -> bool:
         return False
 
 
+def _resolve_qq_cipher(key_bytes: bytes, first_page: bytes):
+    """Return the HMAC-verified SQLCipher parameter tuple for page 1."""
+    raw = b"\0" * 1024 + first_page
+    for kdf, hmac_algo, reserve in _VERIFY_COMBOS:
+        if _verify_key_qq_with_algo(
+            key_bytes, raw, kdf, hmac_algo, reserve
+        ):
+            return kdf, hmac_algo, reserve
+    return None
+
+
+def _decrypt_qq_page(
+    page: bytes,
+    *,
+    page_no: int,
+    salt: bytes,
+    aes_key: bytes,
+    mac_key: bytes,
+    hmac_algo: str,
+    reserve: int,
+) -> Optional[bytes]:
+    """Authenticate and decrypt one current/legacy NTQQ SQLCipher page."""
+    try:
+        from Crypto.Cipher import AES
+    except ImportError:
+        try:
+            from Cryptodome.Cipher import AES
+        except ImportError:
+            return None
+    if len(page) != 4096 or page_no <= 0:
+        return None
+    if hmac_algo == "sha1":
+        hash_func = hashlib.sha1
+        digest_len = 20
+    elif hmac_algo == "sha512":
+        hash_func = hashlib.sha512
+        digest_len = 64
+    else:
+        return None
+    prefix = 16 if page_no == 1 else 0
+    if prefix and page[:16] != salt:
+        return None
+    body = page[prefix:4096 - reserve]
+    iv_start = 4096 - reserve
+    iv = page[iv_start:iv_start + 16]
+    stored_tag = page[
+        iv_start + 16:iv_start + 16 + digest_len
+    ]
+    computed = hmac_mod.new(
+        mac_key,
+        body + iv + struct.pack("<I", page_no),
+        hash_func,
+    ).digest()
+    if not hmac_mod.compare_digest(computed, stored_tag):
+        return None
+    plain = AES.new(aes_key, AES.MODE_CBC, iv).decrypt(body)
+    if page_no == 1:
+        return b"SQLite format 3\x00" + plain + page[4096 - reserve:]
+    return plain + page[4096 - reserve:]
+
+
 def _decrypt_db_qq(db_path: Path, key, output_path: Path) -> bool:
     """Decrypt NTQQ nt_msg.db (post-1024-header-strip) to plain SQLite.
 
-    Uses the verified kdf=SHA-512 + hmac=SHA-1 + reserve=48 combo for
-    NTQQ 9.9.x.
+    Resolves the DB's HMAC-verified current/legacy cipher tuple from page 1,
+    authenticates every main page, then validates and applies committed WAL
+    frames through the copied WAL-index ``mxFrame``.
 
     NTQQ 9.9.x parameters (confirmed by passphrase verify):
       - Key:       16-char ASCII passphrase ({XXXXX...) — wrapper.node sqlite3_key_v2
@@ -696,15 +810,6 @@ def _decrypt_db_qq(db_path: Path, key, output_path: Path) -> bool:
       - Reserve:   48 (16 IV + 20 HMAC + 12 padding) — HMAC-SHA1 default
       - HMAC:      SHA-1 (only for verify, not decrypt)
     """
-    try:
-        from Crypto.Cipher import AES
-    except ImportError:
-        try:
-            from Cryptodome.Cipher import AES
-        except ImportError:
-            logger.warning("pycryptodome not installed — cannot decrypt DB")
-            return False
-
     if isinstance(key, str):
         key_bytes = key.encode("ascii")
     else:
@@ -712,7 +817,6 @@ def _decrypt_db_qq(db_path: Path, key, output_path: Path) -> bool:
 
     PAGE_SZ = 4096
     SALT_SZ = 16
-    RESERVE = 48  # NTQQ 9.9.x: 16 IV + 20 HMAC-SHA1 + 12 padding
     KEY_SZ = 32
 
     try:
@@ -723,30 +827,88 @@ def _decrypt_db_qq(db_path: Path, key, output_path: Path) -> bool:
         with open(db_path, "rb") as f, open(output_path, "wb") as out:
             first = f.read(PAGE_SZ)
             if len(first) < PAGE_SZ:
-                out.write(first)
                 logger.warning(f"DB too small to decrypt: {db_path.name}")
                 return False
             salt = first[:SALT_SZ]
-            enc_key = hashlib.pbkdf2_hmac("sha512", key_bytes, salt, 4000, dklen=KEY_SZ)
-            # Page 1: salt at beginning, then encrypted body
-            iv = first[PAGE_SZ - RESERVE:PAGE_SZ - RESERVE + 16]
-            dec = AES.new(enc_key, AES.MODE_CBC, iv).decrypt(first[SALT_SZ:PAGE_SZ - RESERVE])
-            out.write(b"SQLite format 3\x00" + dec + first[PAGE_SZ - RESERVE:])
+            resolved = _resolve_qq_cipher(key_bytes, first)
+            if resolved is None:
+                raise OSError("page-1 HMAC does not match the supplied key")
+            kdf, hmac_algo, reserve = resolved
+            aes_key = hashlib.pbkdf2_hmac(
+                kdf, key_bytes, salt, 4000, dklen=KEY_SZ
+            )
+            mac_salt = bytes(value ^ 0x3A for value in salt)
+            mac_key = hashlib.pbkdf2_hmac(
+                kdf, aes_key, mac_salt, 2, dklen=KEY_SZ
+            )
+            plain = _decrypt_qq_page(
+                first,
+                page_no=1,
+                salt=salt,
+                aes_key=aes_key,
+                mac_key=mac_key,
+                hmac_algo=hmac_algo,
+                reserve=reserve,
+            )
+            if plain is None:
+                raise OSError("page 1 authentication failed")
+            out.write(plain)
             pages = 1
             while True:
                 page = f.read(PAGE_SZ)
-                if len(page) < PAGE_SZ:
-                    if page:
-                        out.write(page)
+                if not page:
                     break
-                iv = page[PAGE_SZ - RESERVE:PAGE_SZ - RESERVE + 16]
-                dec = AES.new(enc_key, AES.MODE_CBC, iv).decrypt(page[:PAGE_SZ - RESERVE])
-                out.write(dec + page[PAGE_SZ - RESERVE:])
+                if len(page) != PAGE_SZ:
+                    raise OSError("encrypted DB has a truncated trailing page")
+                page_no = pages + 1
+                plain = _decrypt_qq_page(
+                    page,
+                    page_no=page_no,
+                    salt=salt,
+                    aes_key=aes_key,
+                    mac_key=mac_key,
+                    hmac_algo=hmac_algo,
+                    reserve=reserve,
+                )
+                if plain is None:
+                    raise OSError(f"page {page_no} authentication failed")
+                out.write(plain)
                 pages += 1
 
-        logger.info(f"Decrypted {pages} pages reserve={RESERVE} (streaming) -> {output_path}")
+        from chatlog_keeper.core._wal import apply_wal
+        wal_path = db_path.with_name(db_path.name + "-wal")
+        shm_path = db_path.with_name(db_path.name + "-shm")
+        wal_frames = apply_wal(
+            wal_path,
+            output_path,
+            lambda page, page_no: _decrypt_qq_page(
+                page,
+                page_no=page_no,
+                salt=salt,
+                aes_key=aes_key,
+                mac_key=mac_key,
+                hmac_algo=hmac_algo,
+                reserve=reserve,
+            ),
+            shm_path=shm_path,
+            expected_page_size=PAGE_SZ,
+        )
+        logger.info(
+            "Decrypted %d main pages + %d committed WAL frames "
+            "kdf=%s hmac=%s reserve=%d (streaming) -> %s",
+            pages,
+            wal_frames,
+            kdf,
+            hmac_algo,
+            reserve,
+            output_path,
+        )
         return True
     except Exception as e:
+        try:
+            output_path.unlink(missing_ok=True)
+        except OSError:
+            pass
         logger.warning(f"Decryption failed for {db_path.name}: {e}")
         return False
 
@@ -1835,7 +1997,6 @@ class QQDBReader:
         if hours is not None:
             days = max(1, int(hours / 24) or 1)
 
-        import shutil
         tmp_dir = tempfile.mkdtemp(prefix="qq_db_")
 
         try:
@@ -1859,17 +2020,16 @@ class QQDBReader:
                 group_src = nt_db_dir / "group_info.db"
                 tmp_path = Path(tmp_dir)
                 if profile_src.exists():
-                    # Copy first (some NTQQ dbs are locked while QQ.exe runs)
-                    profile_copy = tmp_path / "profile_info_src.db"
-                    shutil.copy2(profile_src, profile_copy)
-                    profile_dec = _decrypt_aux_db(profile_copy, self.key, tmp_path)
+                    profile_dec = _decrypt_aux_db(
+                        profile_src, self.key, tmp_path
+                    )
                     if profile_dec:
                         buddy_map = _build_buddy_name_map(profile_dec)
                         logger.info(f"buddy_map loaded: {len(buddy_map)} entries")
                 if group_src.exists():
-                    group_copy = tmp_path / "group_info_src.db"
-                    shutil.copy2(group_src, group_copy)
-                    group_dec = _decrypt_aux_db(group_copy, self.key, tmp_path)
+                    group_dec = _decrypt_aux_db(
+                        group_src, self.key, tmp_path
+                    )
                     if group_dec:
                         group_map = _build_group_member_map(group_dec)
                         logger.info(f"group_member_map loaded: {len(group_map)} entries")
@@ -1985,7 +2145,7 @@ class QQDBReader:
             "db_path": str(self.db_path) if self.db_path else None,
             "qq_pids": list(pids),
             "key_extracted": self.key is not None,
-            "key_hex": self.key.hex() if self.key else None,
+            "key_length": len(self.key) if self.key else 0,
         }
 
 

--- a/chatlog_keeper/scripts/macos_memory_scan.c
+++ b/chatlog_keeper/scripts/macos_memory_scan.c
@@ -1,0 +1,124 @@
+/*
+ * Read-only Mach memory candidate scanner for chatlog-keeper.
+ *
+ * It does not decrypt databases and never writes to the target process.  The
+ * Python caller validates every candidate against the user's local DB HMAC
+ * before it can be cached.
+ */
+#include <ctype.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHUNK (8u * 1024u * 1024u)
+#define OVERLAP 256u
+
+static int printable(unsigned char c) { return c >= 0x20 && c <= 0x7e; }
+
+static void emit_hex(const char *kind, const unsigned char *p, size_t n) {
+    fputs(kind, stdout);
+    fputc(':', stdout);
+    for (size_t i = 0; i < n; ++i) fprintf(stdout, "%02x", p[i]);
+    fputc('\n', stdout);
+}
+
+static void scan_qq(const unsigned char *p, size_t n) {
+    size_t i = 0;
+    while (i < n) {
+        if (!printable(p[i])) {
+            ++i;
+            continue;
+        }
+        size_t j = i;
+        while (j < n && printable(p[j])) ++j;
+        size_t len = j - i;
+        if ((len == 16 || len == 32) && j < n && p[j] == 0 &&
+            (i == 0 || p[i - 1] == 0)) {
+            emit_hex("QQ", p + i, len);
+        }
+        i = j + (j < n ? 1 : 0);
+    }
+}
+
+static int hexch(unsigned char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+static void scan_wechat(const unsigned char *p, size_t n) {
+    for (size_t i = 0; i + 67 < n; ++i) {
+        if (p[i] != 'x' || p[i + 1] != '\'') continue;
+        size_t j = i + 2;
+        while (j < n && hexch(p[j]) && j - (i + 2) <= 192) ++j;
+        size_t len = j - (i + 2);
+        if (len >= 64 && j < n && p[j] == '\'') {
+            /* The first 64 hex chars are the 32-byte master-key candidate. */
+            unsigned char key[32];
+            for (size_t k = 0; k < 32; ++k) {
+                unsigned int v = 0;
+                sscanf((const char *)(p + i + 2 + 2 * k), "%2x", &v);
+                key[k] = (unsigned char)v;
+            }
+            emit_hex("WX", key, sizeof(key));
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3 || (strcmp(argv[1], "qq") && strcmp(argv[1], "wechat"))) {
+        fprintf(stderr, "usage: macos-memory-scan <qq|wechat> <pid>\n");
+        return 2;
+    }
+    char *end = NULL;
+    long parsed = strtol(argv[2], &end, 10);
+    if (!end || *end || parsed <= 0) return 2;
+
+    mach_port_t task = MACH_PORT_NULL;
+    kern_return_t kr = task_for_pid(mach_task_self(), (pid_t)parsed, &task);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stderr, "task_for_pid:%d\n", kr);
+        return 3;
+    }
+
+    unsigned char *buf = malloc(CHUNK + OVERLAP);
+    if (!buf) return 4;
+    mach_vm_address_t address = 0;
+    while (1) {
+        mach_vm_size_t region_size = 0;
+        vm_region_basic_info_data_64_t info;
+        mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+        mach_port_t object_name = MACH_PORT_NULL;
+        kr = mach_vm_region(
+            task, &address, &region_size, VM_REGION_BASIC_INFO_64,
+            (vm_region_info_t)&info, &count, &object_name);
+        if (kr != KERN_SUCCESS) break;
+        if ((info.protection & VM_PROT_READ) && region_size > 0) {
+            mach_vm_size_t offset = 0;
+            size_t carry = 0;
+            while (offset < region_size) {
+                mach_vm_size_t want = region_size - offset;
+                if (want > CHUNK) want = CHUNK;
+                mach_vm_size_t got = 0;
+                kr = mach_vm_read_overwrite(
+                    task, address + offset, want,
+                    (mach_vm_address_t)(buf + carry), &got);
+                if (kr != KERN_SUCCESS || got == 0) break;
+                size_t total = carry + (size_t)got;
+                if (!strcmp(argv[1], "qq")) scan_qq(buf, total);
+                else scan_wechat(buf, total);
+                carry = total < OVERLAP ? total : OVERLAP;
+                memmove(buf, buf + total - carry, carry);
+                offset += got;
+            }
+        }
+        if (object_name != MACH_PORT_NULL) mach_port_deallocate(mach_task_self(), object_name);
+        mach_vm_address_t next = address + region_size;
+        if (next <= address) break;
+        address = next;
+    }
+    free(buf);
+    mach_port_deallocate(mach_task_self(), task);
+    return 0;
+}

--- a/chatlog_keeper/wechat_db.py
+++ b/chatlog_keeper/wechat_db.py
@@ -21,6 +21,7 @@ import os
 import re
 import struct
 import subprocess
+import sys
 import tempfile
 from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
@@ -80,6 +81,10 @@ def _get_weixin_pids() -> list:
     the SQLCipher enc_keys in heap. This avoids the repeated "Key extraction
     failed" log spam that happens when descending order tries worker pids first.
     """
+    if sys.platform == "darwin":
+        from chatlog_keeper.core._macos import process_pids
+        return process_pids(("WeChat", "Weixin"))
+
     # A 5s tasklist timeout was too tight on loaded systems (caused a false
     # "Weixin.exe not running" when many Weixin instances + concurrent Python
     # processes saturated the tasklist response). Use 30s + retry once on
@@ -133,13 +138,17 @@ def find_weixin_data_root() -> Optional[Path]:
     env = os.environ.get("CHATLOG_WECHAT_DATA_ROOT", "").strip()
     if env:
         candidates.append(Path(env))
-    for drive in all_drive_roots():
-        candidates.append(drive / "wechat files" / "xwechat_files")
-        candidates.append(drive / "xwechat_files")
-        candidates.append(drive / "WeChat Files")
-    for doc in candidate_documents_roots():
-        candidates.append(doc / "xwechat_files")
-        candidates.append(doc / "WeChat Files")
+    if sys.platform == "darwin":
+        from chatlog_keeper.core._macos import wechat_data_roots
+        candidates.extend(wechat_data_roots())
+    else:
+        for drive in all_drive_roots():
+            candidates.append(drive / "wechat files" / "xwechat_files")
+            candidates.append(drive / "xwechat_files")
+            candidates.append(drive / "WeChat Files")
+        for doc in candidate_documents_roots():
+            candidates.append(doc / "xwechat_files")
+            candidates.append(doc / "WeChat Files")
 
     seen: set = set()
     for c in candidates:
@@ -324,12 +333,18 @@ def save_cached_wechat_key(key: bytes) -> bool:
     if not key or len(key) != 32:
         return False
     p = _wechat_key_cache_path()
+    from chatlog_keeper.core._secrets import write_secret_text
+    return write_secret_text(p, bytes(key).hex())
+
+
+def _read_stable_page1(db_path: Path) -> Optional[bytes]:
+    """Return a checkpoint-safe SQLCipher page 1, or ``None`` if still busy."""
+    from chatlog_keeper.core._snapshot import read_stable_prefix
+
     try:
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(bytes(key).hex(), encoding="utf-8")
-        return True
+        return read_stable_prefix(Path(db_path), 4096)
     except OSError:
-        return False
+        return None
 
 
 def _scan_memory_for_key(pid: int, db_path: Path = None,
@@ -341,6 +356,21 @@ def _scan_memory_for_key(pid: int, db_path: Path = None,
     in process heap as plain ASCII.  We scan all readable regions for this
     pattern and validate each candidate with HMAC-SHA512 against db_path page 1.
     """
+    if sys.platform == "darwin":
+        if not db_path or not Path(db_path).is_file():
+            return None
+        db_page1 = _read_stable_page1(Path(db_path))
+        if not db_page1:
+            return None
+        from chatlog_keeper.macos_key import extract_verified
+        return extract_verified(
+            "wechat",
+            pid,
+            lambda candidate: _verify_key_v4(candidate, db_page1),
+            elevate=False,
+            timeout=max(1, int(timeout_s or 120)),
+        )
+
     kernel32 = ctypes.windll.kernel32
     PROCESS_VM_READ = 0x0010
     PROCESS_QUERY_INFORMATION = 0x0400
@@ -457,11 +487,7 @@ def extract_key_from_weixin(pid: int, db_path: Path = None,
     """
     db_page1 = None
     if db_path and Path(db_path).exists():
-        try:
-            with open(db_path, "rb") as f:
-                db_page1 = f.read(4096)
-        except OSError:
-            db_page1 = None
+        db_page1 = _read_stable_page1(Path(db_path))
 
     # 1. Cache fast-path (self-healing: only used if it HMAC-verifies the live DB).
     if db_page1:
@@ -487,6 +513,18 @@ def extract_key_from_weixin(pid: int, db_path: Path = None,
 # ─── Database decryption ──────────────────────────────────────────────────────
 
 def _decrypt_db_v4(db_path: Path, enc_key: bytes, output_path: Path) -> bool:
+    """Snapshot the live DB family, then decrypt main DB and committed WAL."""
+    from chatlog_keeper.core._snapshot import snapshot_db_family
+
+    try:
+        with snapshot_db_family(db_path) as snapshot:
+            return _decrypt_db_v4_snapshot(snapshot, enc_key, output_path)
+    except OSError as exc:
+        logger.warning("Could not snapshot %s: %s", Path(db_path).name, exc)
+        return False
+
+
+def _decrypt_db_v4_snapshot(db_path: Path, enc_key: bytes, output_path: Path) -> bool:
     """
     Decrypt a Weixin 4.x SQLCipher DB to plain SQLite.
 
@@ -542,11 +580,76 @@ def _decrypt_db_v4(db_path: Path, enc_key: bytes, output_path: Path) -> bool:
                 out.write(dec + page[PAGE_SZ - RESERVE:])
                 pages += 1
 
-        logger.info(f"Decrypted {pages} pages (streaming) → {output_path}")
+        wal_frames = _apply_wechat_wal(
+            db_path.with_name(db_path.name + "-wal"),
+            page_key,
+            first[:SALT_SZ],
+            output_path,
+        )
+        logger.info(
+            "Decrypted %d main pages + %d committed WAL frames (streaming) → %s",
+            pages,
+            wal_frames,
+            output_path,
+        )
         return True
     except Exception as e:
         logger.warning(f"Decryption failed for {db_path.name}: {e}")
         return False
+
+
+def _decrypt_wal_page(page: bytes, page_key: bytes, salt: bytes, page_no: int) -> Optional[bytes]:
+    """HMAC-verify and decrypt one SQLCipher-4 WAL page image."""
+    try:
+        from Crypto.Cipher import AES
+    except ImportError:
+        try:
+            from Cryptodome.Cipher import AES
+        except ImportError:
+            return None
+    page_size = 4096
+    reserve = 80
+    if len(page) != page_size or page_no <= 0:
+        return None
+    mac_salt = bytes(b ^ 0x3A for b in salt)
+    mac_key = hashlib.pbkdf2_hmac("sha512", page_key, mac_salt, 2, dklen=32)
+    prefix = 16 if page_no == 1 else 0
+    hm = hmac_mod.new(mac_key, page[prefix: page_size - 64], hashlib.sha512)
+    hm.update(struct.pack("<I", page_no))
+    if not hmac_mod.compare_digest(hm.digest(), page[page_size - 64:]):
+        return None
+    iv = page[page_size - reserve: page_size - 64]
+    body = AES.new(page_key, AES.MODE_CBC, iv).decrypt(
+        page[prefix: page_size - reserve]
+    )
+    if page_no == 1:
+        return b"SQLite format 3\x00" + body + page[page_size - reserve:]
+    return body + page[page_size - reserve:]
+
+
+def _apply_wechat_wal(
+    wal_path: Path,
+    page_key: bytes,
+    salt: bytes,
+    output_path: Path,
+) -> int:
+    """Apply structurally-valid, HMAC-valid frames through ``mxFrame``."""
+    from chatlog_keeper.core._wal import apply_wal
+
+    shm_path = wal_path.with_name(
+        wal_path.name[:-4] + "-shm"
+        if wal_path.name.endswith("-wal")
+        else wal_path.name + "-shm"
+    )
+    return apply_wal(
+        wal_path,
+        output_path,
+        lambda page, page_no: _decrypt_wal_page(
+            page, page_key, salt, page_no
+        ),
+        shm_path=shm_path,
+        expected_page_size=4096,
+    )
 
 
 # ─── Message reading ──────────────────────────────────────────────────────────
@@ -1602,10 +1705,8 @@ class WeChatDBReader:
         cached = load_cached_wechat_key()
         if cached and len(cached) == 32:
             for db in db_files:
-                try:
-                    with open(db, "rb") as f:
-                        page1 = f.read(4096)
-                except OSError:
+                page1 = _read_stable_page1(db)
+                if not page1:
                     continue
                 if _verify_key_v4(cached, page1):
                     self.enc_keys[db] = cached
@@ -1754,7 +1855,7 @@ class WeChatDBReader:
             if db_key is None:
                 logger.warning(f"Skipping {db_file.name}: no enc_key in self.enc_keys")
                 continue
-            logger.info(f"Querying {db_file.name} (key={db_key.hex()[:16]}...) ...")
+            logger.info("Querying %s with a verified cached key", db_file.name)
             msgs = query_messages_by_date(db_file, target_date, db_key)
             all_messages.extend(msgs)
 
@@ -1817,10 +1918,9 @@ class WeChatDBReader:
             "wxid_dir": str(self.wxid_dir) if self.wxid_dir else None,
             "weixin_pids": list(pids),
             "key_extracted": self.enc_key is not None,
-            "key_hex": self.enc_key.hex() if self.enc_key else None,
+            "key_length": len(self.enc_key) if self.enc_key else 0,
             "db_files_found": [str(f) for f in db_files],
             "per_db_keys_count": len(self.enc_keys),  # 2026-04-30
-            "per_db_keys": {db.name: k.hex()[:16] + "..." for db, k in self.enc_keys.items()},
         }
 
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,85 @@
+# macOS setup, security model, and troubleshooting
+
+chatlog-keeper 0.2 adds native Apple Silicon support for the current sandboxed
+WeChat and QQ desktop clients. The command names and JSON/HTML export format
+are the same as on Windows.
+
+## What the tool changes
+
+The normal export path is read-only with respect to both chat clients. It:
+
+1. locates the current user's sandbox container;
+2. snapshots the encrypted database family into a private temporary directory;
+3. verifies a cached or newly observed key against database page 1;
+4. decrypts the snapshot and committed WAL frames locally; and
+5. writes only the requested JSON/HTML export.
+
+It does not inject code, send messages, contact Tencent, disable SIP, or modify
+the app installed under `/Applications`.
+
+## Key acquisition
+
+`extract-key --method passive` asks the normal user process for read-only Mach
+access. Modern hardened clients usually deny that request.
+
+`extract-key --method active` is explicit and interactive:
+
+- an isolated copy is created under
+  `~/Library/Application Support/chatlog-keeper/debug-apps/`;
+- the copy preserves the original entitlements and adds only
+  `com.apple.security.get-task-allow`;
+- the copy is ad-hoc signed and verified before launch;
+- macOS displays its own administrator authentication dialog;
+- a bundled helper reads candidate bytes without writing to the client; and
+- Python discards every candidate that fails the real database HMAC oracle.
+
+The original app remains unchanged. A client update creates a new
+content-addressed isolated copy rather than silently reusing the previous one.
+
+## Files and permissions
+
+Writable state lives under:
+
+```text
+~/Library/Application Support/chatlog-keeper/
+├── bin/          # private compiled/copied Mach helper
+├── debug-apps/   # isolated active-extraction app copies
+└── secrets/      # cached DB keys
+```
+
+`secrets/` is mode `0700`; key files are written atomically with mode `0600`.
+The tool never prints a successful key in its JSON result or diagnostics.
+
+## Commands
+
+```bash
+chatlog-keeper probe
+chatlog-keeper extract-key --source wechat --method active
+chatlog-keeper extract-key --source qq --method active
+chatlog-keeper wechat --days 7 --out ./out
+chatlog-keeper qq --days 7 --out ./out
+```
+
+The active flow may open a separate WeChat or QQ window. Log into that isolated
+window only if the client asks. Enter administrator credentials only into the
+macOS-owned authentication dialog.
+
+## Troubleshooting
+
+- `administrator username or password was not accepted`: rerun the command
+  from the logged-in desktop session and complete the macOS authentication
+  dialog. SSH cannot safely substitute for that user interaction.
+- `process_access_denied`: the isolated copy was not accepted by taskgated.
+  Keep SIP enabled; remove no protections. Rebuild the isolated copy after a
+  client update and retry.
+- data root not found: pass the container's `xwechat_files` or QQ application
+  support directory with `--data-root`.
+- source install reports `helper_compile_failed`: install Xcode Command Line
+  Tools. The standalone arm64 release already contains the compiled helper.
+- container access denied: give the invoking host application (Terminal or the
+  desktop host) Full Disk Access in System Settings, then relaunch it.
+
+## Current release boundary
+
+The standalone macOS asset is arm64-only. Intel Macs can run the Python source
+build, but they are not part of the 0.2 release gate.

--- a/docs/macos.zh.md
+++ b/docs/macos.zh.md
@@ -1,0 +1,76 @@
+# macOS 设置、安全模型与排障
+
+chatlog-keeper 0.2 为当前沙盒版微信和 QQ 增加 Apple Silicon 原生支持。命令名以及
+JSON/HTML 导出格式与 Windows 完全一致。
+
+## 工具会改什么
+
+普通导出对两个聊天客户端都是只读的：
+
+1. 定位当前用户的 sandbox container；
+2. 把加密数据库及 `-wal`、`-shm` 一致性快照到私有临时目录；
+3. 用数据库第一页验证缓存或新发现的 key；
+4. 仅在本机解密快照和已提交 WAL；
+5. 只写用户指定的 JSON/HTML 导出目录。
+
+工具不会注入代码、不会发消息、不会连接腾讯服务器、不会关闭 SIP，也不会修改
+`/Applications` 下的原应用。
+
+## 取 key
+
+`extract-key --method passive` 用当前普通用户身份请求只读 Mach 访问。现代 hardened
+客户端通常会拒绝。
+
+`extract-key --method active` 是显式、可见的交互流程：
+
+- 在 `~/Library/Application Support/chatlog-keeper/debug-apps/` 创建隔离副本；
+- 保留原 entitlements，只增加 `com.apple.security.get-task-allow`；
+- ad-hoc 签名并验证通过后才启动；
+- macOS 自己弹出管理员认证框；
+- 内置 helper 只读候选字节，不向客户端写入；
+- 任何未通过真实数据库 HMAC oracle 的候选都会被 Python 丢弃。
+
+原应用保持不变。客户端升级后会按新内容身份创建新的隔离副本，不会静默复用旧副本。
+
+## 文件与权限
+
+```text
+~/Library/Application Support/chatlog-keeper/
+├── bin/          # 私有 Mach helper
+├── debug-apps/   # 主动流程的隔离应用副本
+└── secrets/      # 已缓存数据库 key
+```
+
+`secrets/` 权限为 `0700`；key 文件采用原子写入且权限为 `0600`。成功 key 不会出现在
+JSON 返回值或诊断日志中。
+
+## 命令
+
+```bash
+chatlog-keeper probe
+chatlog-keeper extract-key --source wechat --method active
+chatlog-keeper extract-key --source qq --method active
+chatlog-keeper wechat --days 7 --out ./out
+chatlog-keeper qq --days 7 --out ./out
+```
+
+主动流程可能打开独立微信或 QQ 窗口；只有客户端确实要求时才登录。管理员凭据只能输入
+macOS 自己的认证框，不要输入终端或第三方界面。
+
+## 常见问题
+
+- `administrator username or password was not accepted`：从当前已登录的桌面会话重跑，
+  并完成 macOS 认证框；SSH 不能安全代替这一步人工操作。
+- `process_access_denied`：taskgated 没接受隔离副本。保持 SIP 开启，不要降低系统保护；
+  客户端升级后重建隔离副本再试。
+- 找不到数据目录：用 `--data-root` 显式传入微信 `xwechat_files` 或 QQ Application
+  Support 目录。
+- 源码安装报 `helper_compile_failed`：安装 Xcode Command Line Tools；arm64 独立包已
+  内置编译后的 helper。
+- container 拒绝访问：在系统设置中给实际调用者（Terminal 或桌面宿主）开启“完全磁盘
+  访问权限”，然后重启调用者。
+
+## 当前发布边界
+
+macOS 独立资产目前只提供 arm64。Intel Mac 可以运行 Python 源码版，但不在 0.2 的发布
+验收范围内。

--- a/packaging/chatlog_keeper.spec
+++ b/packaging/chatlog_keeper.spec
@@ -1,17 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
-"""PyInstaller spec — standalone one-file ``chatlog-keeper.exe``.
+"""PyInstaller spec — standalone one-file ``chatlog-keeper`` executable.
 
 Build from the repo root:
     pyinstaller packaging/chatlog_keeper.spec --noconfirm --clean --distpath dist_exe
 
-Produces a single self-contained ``chatlog-keeper.exe`` (key extraction +
-decrypt + export) for host apps / scheduled tasks to download and invoke. The
-two PowerShell debugger scripts are bundled under ``chatlog_keeper/scripts`` so
-``active_key._scripts_dir()`` finds them via ``sys._MEIPASS`` when frozen.
+Produces one self-contained executable (``.exe`` on Windows) for host apps /
+scheduled tasks to invoke. The Windows PowerShell debugger scripts and macOS
+Mach scanner source are bundled under ``chatlog_keeper/scripts`` so the
+platform key helper can find them through ``sys._MEIPASS`` when frozen.
 """
 import os
 import sys as _sys
 import glob as _glob
+import subprocess as _subprocess
 
 from PyInstaller.utils.hooks import collect_all
 
@@ -26,8 +27,38 @@ binaries = []
 datas = [
     (os.path.join(SCRIPTS_SRC, "windows_ntqq_get_key.ps1"), SCRIPTS_DST),
     (os.path.join(SCRIPTS_SRC, "windows_wechat_get_key.ps1"), SCRIPTS_DST),
+    (os.path.join(SCRIPTS_SRC, "macos_memory_scan.c"), SCRIPTS_DST),
 ]
 hiddenimports = []
+
+# A standalone macOS release must not require Xcode Command Line Tools on the
+# user's machine. Compile the read-only Mach helper on the arm64 build runner
+# and embed it next to the source fallback. Source installs still compile the C
+# file on first use, which keeps the implementation auditable.
+if _sys.platform == "darwin":
+    _mac_helper_dir = os.path.join(ROOT, "build_pyi", "macos-helper")
+    os.makedirs(_mac_helper_dir, exist_ok=True)
+    _mac_helper = os.path.join(_mac_helper_dir, "macos_memory_scan")
+    _compiled = _subprocess.run(
+        [
+            "xcrun",
+            "clang",
+            "-O2",
+            "-Wall",
+            "-Wextra",
+            os.path.join(SCRIPTS_SRC, "macos_memory_scan.c"),
+            "-o",
+            _mac_helper,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if _compiled.returncode != 0:
+        raise RuntimeError(
+            "failed to compile macOS key helper: " + (_compiled.stderr or "").strip()
+        )
+    datas.append((_mac_helper, SCRIPTS_DST))
 
 # ── conda-env C-extension runtime DLLs (Library/bin) ────────────────────────
 # A conda build's _ctypes.pyd / _ssl / _hashlib / lzma / bz2 / sqlite3 load their

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatlog-keeper"
-version = "0.1.1"
+version = "0.2.0"
 description = "Decrypt and export your own local QQ / WeChat chat history for personal backup and nostalgia. Local-only; nothing is uploaded."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -16,6 +16,7 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -49,4 +50,4 @@ include = ["chatlog_keeper*"]
 
 [tool.setuptools.package-data]
 # Bundle the PowerShell debugger scripts used by `extract-key --method active`.
-chatlog_keeper = ["scripts/*.ps1"]
+chatlog_keeper = ["scripts/*.ps1", "scripts/*.c"]

--- a/tests/test_active_key.py
+++ b/tests/test_active_key.py
@@ -5,6 +5,7 @@ run anywhere (CI included). The debugger run itself can't be unit-tested without
 a live client; what we lock down here is everything around it: how a key line is
 recognized, how the newest install is chosen, and that the scripts are bundled.
 """
+from chatlog_keeper import macos_debug_app, macos_key, qq_db, wechat_db
 from chatlog_keeper import active_key as ak
 
 
@@ -82,3 +83,95 @@ def test_debugger_scripts_are_bundled():
     assert wx is not None and wx.exists()
     assert qq.name == "windows_ntqq_get_key.ps1"
     assert wx.name == "windows_wechat_get_key.ps1"
+
+
+def test_macos_wechat_does_not_fallback_to_sip_protected_daily_app(
+    monkeypatch, tmp_path
+):
+    db = tmp_path / "message_0.db"
+    db.write_bytes(b"x" * 4096)
+    called = []
+
+    monkeypatch.setattr(ak.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        macos_debug_app,
+        "launch_debug_copy",
+        lambda source: None,
+    )
+    monkeypatch.setattr(
+        macos_key,
+        "extract_verified",
+        lambda *args, **kwargs: called.append((args, kwargs)),
+    )
+
+    assert ak.extract_wechat_key_active(db_path=str(db), timeout=1) is None
+    assert called == []
+
+
+def test_macos_wechat_rechecks_page1_after_scan(monkeypatch, tmp_path):
+    db = tmp_path / "message_0.db"
+    db.write_bytes(b"x" * 4096)
+    key = bytes(range(32))
+    pages = iter((b"A" * 4096, b"B" * 4096, b"C" * 4096, b"C" * 4096))
+    scans = []
+    rechecks = iter((False, True))
+
+    monkeypatch.setattr(ak.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        macos_debug_app,
+        "launch_debug_copy",
+        lambda source: 42,
+    )
+    monkeypatch.setattr(
+        wechat_db,
+        "_read_stable_page1",
+        lambda path: next(pages),
+    )
+    monkeypatch.setattr(
+        macos_key,
+        "extract_verified",
+        lambda *args, **kwargs: scans.append(args[1]) or key,
+    )
+    monkeypatch.setattr(
+        wechat_db,
+        "_verify_key_v4",
+        lambda candidate, page: next(rechecks),
+    )
+
+    assert ak.extract_wechat_key_active(db_path=str(db), timeout=1) == key
+    assert scans == [42, 42]
+
+
+def test_macos_qq_rechecks_oracle_after_scan_and_retries(
+    monkeypatch, tmp_path
+):
+    db = tmp_path / "nt_msg.db"
+    db.write_bytes(b"x" * 5120)
+    key = b"0123456789abcdef"
+    pages = iter((b"A" * 5120, b"B" * 5120, b"C" * 5120, b"C" * 5120))
+    scans = []
+
+    monkeypatch.setattr(ak.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        macos_debug_app,
+        "launch_debug_copy",
+        lambda source: 42,
+    )
+    monkeypatch.setattr(
+        qq_db,
+        "_read_qq_verification_bytes",
+        lambda path: next(pages),
+    )
+    monkeypatch.setattr(
+        macos_key,
+        "extract_verified",
+        lambda *args, **kwargs: scans.append(args[1]) or key,
+    )
+    monkeypatch.setattr(
+        qq_db,
+        "_verify_key_qq",
+        lambda candidate, page: page == b"C" * 5120,
+    )
+
+    assert ak.extract_qq_key_active(db_path=str(db), timeout=1) == key
+    assert scans == [42, 42]

--- a/tests/test_cli_extract_key.py
+++ b/tests/test_cli_extract_key.py
@@ -46,6 +46,7 @@ def test_wechat_data_root_discovers_root_level_relocation(monkeypatch, tmp_path)
     relocated = tmp_path / "xwechat_files"
     relocated.mkdir()
     monkeypatch.delenv("CHATLOG_WECHAT_DATA_ROOT", raising=False)
+    monkeypatch.setattr(wechat_db.sys, "platform", "win32")
     monkeypatch.setattr(_paths, "all_drive_roots", lambda: [tmp_path])
     monkeypatch.setattr(_paths, "candidate_documents_roots", lambda: [])
 

--- a/tests/test_cli_set_key.py
+++ b/tests/test_cli_set_key.py
@@ -1,0 +1,17 @@
+import io
+
+from chatlog_keeper import cli
+
+
+def test_set_key_can_be_read_from_stdin_without_argv_secret(monkeypatch):
+    seen = {}
+
+    def fake_set_key(source, key):
+        seen.update(source=source, key=key)
+        return {"source": source, "ok": True}
+
+    monkeypatch.setattr(cli, "_set_key", fake_set_key)
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("0123456789abcdef\n"))
+
+    assert cli.main(["set-key", "--source", "qq", "--key-stdin"]) == 0
+    assert seen == {"source": "qq", "key": "0123456789abcdef\n"}

--- a/tests/test_macos_debug_app.py
+++ b/tests/test_macos_debug_app.py
@@ -1,0 +1,226 @@
+import plistlib
+import shutil
+from pathlib import Path
+
+from chatlog_keeper import macos_debug_app
+
+
+def test_prepare_debug_copy_is_macos_only(monkeypatch):
+    monkeypatch.setattr(macos_debug_app.sys, "platform", "win32")
+    assert macos_debug_app.prepare_debug_copy("wechat") is None
+
+
+def test_launch_debug_copy_returns_exact_copy_pid(monkeypatch, tmp_path):
+    app = tmp_path / "WeChat.app"
+    executable = app / "Contents" / "MacOS" / "WeChat"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"")
+    monkeypatch.setattr(macos_debug_app, "prepare_debug_copy", lambda source: app)
+    monkeypatch.setattr(
+        macos_debug_app,
+        "_run",
+        lambda *args, **kwargs: type("Result", (), {"returncode": 0})(),
+    )
+    from chatlog_keeper.core import _macos
+    monkeypatch.setattr(_macos, "process_pids_for_executable", lambda path: [314])
+    assert macos_debug_app.launch_debug_copy("wechat", wait_s=0) == 314
+
+
+def test_launch_debug_copy_rejects_ephemeral_pid(monkeypatch, tmp_path):
+    app = tmp_path / "WeChat.app"
+    executable = app / "Contents" / "MacOS" / "WeChat"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"")
+    monkeypatch.setattr(macos_debug_app, "prepare_debug_copy", lambda source: app)
+    monkeypatch.setattr(
+        macos_debug_app,
+        "_run",
+        lambda *args, **kwargs: type("Result", (), {"returncode": 0})(),
+    )
+    from chatlog_keeper.core import _macos
+    states = iter(([], [314], [], [], []))
+    monkeypatch.setattr(
+        _macos,
+        "process_pids_for_executable",
+        lambda path: next(states, []),
+    )
+    clock = {"now": 0.0}
+
+    def monotonic():
+        clock["now"] += 0.25
+        return clock["now"]
+
+    monkeypatch.setattr(macos_debug_app.time, "monotonic", monotonic)
+    monkeypatch.setattr(macos_debug_app.time, "sleep", lambda seconds: None)
+
+    assert macos_debug_app.launch_debug_copy(
+        "wechat", wait_s=1.0, settle_s=0.5
+    ) is None
+
+
+def test_failed_debug_copy_leaves_no_partial_canonical_app(monkeypatch, tmp_path):
+    original = tmp_path / "Applications" / "WeChat.app"
+    info = original / "Contents" / "Info.plist"
+    info.parent.mkdir(parents=True)
+    info.write_bytes(plistlib.dumps({"CFBundleExecutable": "WeChat"}))
+    executable = original / "Contents" / "MacOS" / "WeChat"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"main")
+    private_root = tmp_path / "private"
+    monkeypatch.setattr(macos_debug_app.sys, "platform", "darwin")
+    monkeypatch.setitem(macos_debug_app._APPS, "wechat", (original, "WeChat"))
+    monkeypatch.setattr(macos_debug_app, "data_dir", lambda: private_root)
+    monkeypatch.setattr(
+        macos_debug_app,
+        "_run",
+        lambda *args, **kwargs: type("Result", (), {"returncode": 1})(),
+    )
+
+    assert macos_debug_app.prepare_debug_copy("wechat") is None
+    debug_root = private_root / "debug-apps"
+    assert debug_root.is_dir()
+    assert list(debug_root.iterdir()) == []
+
+
+def test_prepare_debug_copy_does_not_deep_resign_nested_helpers(
+    monkeypatch, tmp_path
+):
+    original = tmp_path / "Applications" / "QQ.app"
+    info = original / "Contents" / "Info.plist"
+    info.parent.mkdir(parents=True)
+    info.write_bytes(plistlib.dumps({"CFBundleExecutable": "QQ"}))
+    executable = original / "Contents" / "MacOS" / "QQ"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"main")
+    private_root = tmp_path / "private"
+    signing_calls = []
+    entitlement_xml = plistlib.dumps(
+        {"com.apple.security.get-task-allow": True},
+        fmt=plistlib.FMT_XML,
+    ).decode("utf-8")
+
+    monkeypatch.setattr(macos_debug_app.sys, "platform", "darwin")
+    monkeypatch.setitem(macos_debug_app._APPS, "qq", (original, "QQ"))
+    monkeypatch.setattr(macos_debug_app, "data_dir", lambda: private_root)
+
+    def fake_run(argv, timeout=300):
+        if argv[0] == "/usr/bin/ditto":
+            shutil.copytree(argv[1], argv[2])
+        if argv[0] == "codesign" and "--force" in argv:
+            signing_calls.append(argv)
+        stdout = entitlement_xml if argv[:3] == [
+            "codesign", "-d", "--entitlements"
+        ] else ""
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": stdout, "stderr": ""},
+        )()
+
+    monkeypatch.setattr(macos_debug_app, "_run", fake_run)
+
+    target = macos_debug_app.prepare_debug_copy("qq")
+    assert target is not None
+    assert len(signing_calls) == 1
+    assert "--deep" not in signing_calls[0]
+    assert "--entitlements" in signing_calls[0]
+
+
+def test_prepare_debug_copy_accepts_only_verified_concurrent_winner(
+    monkeypatch, tmp_path
+):
+    original = tmp_path / "Applications" / "QQ.app"
+    info = original / "Contents" / "Info.plist"
+    info.parent.mkdir(parents=True)
+    info.write_bytes(plistlib.dumps({"CFBundleExecutable": "QQ"}))
+    executable = original / "Contents" / "MacOS" / "QQ"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"main")
+    private_root = tmp_path / "private"
+    entitlement_xml = plistlib.dumps(
+        {"com.apple.security.get-task-allow": True},
+        fmt=plistlib.FMT_XML,
+    ).decode("utf-8")
+
+    monkeypatch.setattr(macos_debug_app.sys, "platform", "darwin")
+    monkeypatch.setitem(macos_debug_app._APPS, "qq", (original, "QQ"))
+    monkeypatch.setattr(macos_debug_app, "data_dir", lambda: private_root)
+
+    def fake_run(argv, timeout=300):
+        if argv[0] == "/usr/bin/ditto":
+            shutil.copytree(argv[1], argv[2])
+        stdout = entitlement_xml if argv[:3] == [
+            "codesign", "-d", "--entitlements"
+        ] else ""
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": stdout, "stderr": ""},
+        )()
+
+    original_replace = Path.replace
+
+    def concurrent_replace(stage, target):
+        # Simulate another process publishing the same fully-verified staged
+        # directory before this process reaches rename(2).  macOS commonly
+        # reports the losing directory rename as a generic OSError.
+        shutil.copytree(stage, target)
+        raise OSError("directory rename race")
+
+    monkeypatch.setattr(macos_debug_app, "_run", fake_run)
+    monkeypatch.setattr(Path, "replace", concurrent_replace)
+    try:
+        target = macos_debug_app.prepare_debug_copy("qq")
+    finally:
+        monkeypatch.setattr(Path, "replace", original_replace)
+    assert target is not None
+    assert (
+        target / "Contents" / "Resources" / ".chatlog-keeper-debug-copy"
+    ).is_file()
+
+
+def test_debug_copy_identity_changes_with_main_executable(tmp_path):
+    first = tmp_path / "first.app"
+    second = tmp_path / "second.app"
+    for app, content in ((first, b"build-one"), (second, b"build-two")):
+        info = app / "Contents" / "Info.plist"
+        info.parent.mkdir(parents=True)
+        info.write_bytes(plistlib.dumps({"CFBundleExecutable": "QQ"}))
+        executable = app / "Contents" / "MacOS" / "QQ"
+        executable.parent.mkdir(parents=True)
+        executable.write_bytes(content)
+    assert macos_debug_app._app_identity(first) != macos_debug_app._app_identity(
+        second
+    )
+
+
+def test_verified_debug_copy_rejects_wrong_marker_content(
+    monkeypatch, tmp_path
+):
+    target = tmp_path / "QQ.app"
+    marker = (
+        target
+        / "Contents"
+        / "Resources"
+        / ".chatlog-keeper-debug-copy"
+    )
+    marker.parent.mkdir(parents=True)
+    marker.write_text("wrong", encoding="ascii")
+    monkeypatch.setattr(
+        macos_debug_app,
+        "_entitlements",
+        lambda app: {"com.apple.security.get-task-allow": True},
+    )
+    monkeypatch.setattr(
+        macos_debug_app,
+        "_run",
+        lambda *args, **kwargs: type(
+            "Result", (), {"returncode": 0, "stdout": "", "stderr": ""}
+        )(),
+    )
+    assert (
+        macos_debug_app._verified_debug_copy(
+            target, marker, "expected"
+        )
+        is False
+    )

--- a/tests/test_macos_key.py
+++ b/tests/test_macos_key.py
@@ -1,0 +1,269 @@
+import subprocess
+import plistlib
+
+from chatlog_keeper import macos_key
+
+
+def _debugger_entitlements_xml():
+    return plistlib.dumps(
+        {"com.apple.security.cs.debugger": True},
+        fmt=plistlib.FMT_XML,
+    ).decode("utf-8")
+
+
+def test_parse_candidates_deduplicates_and_rejects_noise():
+    text = "QQ:31323334353637383930616263646566\nbad\nQQ:zz\nQQ:31323334353637383930616263646566"
+    assert list(macos_key._parse_candidates(text, "QQ")) == [b"1234567890abcdef"]
+
+
+def test_qq_candidates_rank_16_byte_frequency_before_legacy_32_byte():
+    frequent = b"B" * 16
+    rare = b"A" * 16
+    legacy = b"C" * 32
+    text = "\n".join(
+        [
+            "QQ:" + legacy.hex(),
+            "QQ:" + rare.hex(),
+            "QQ:" + frequent.hex(),
+            "QQ:" + frequent.hex(),
+            "QQ:" + frequent.hex(),
+            "QQ:" + (b"bad-length").hex(),
+        ]
+    )
+    assert macos_key._rank_candidates(text, "QQ", (16, 32)) == [
+        frequent,
+        rare,
+        legacy,
+    ]
+
+
+def test_qq_primary_oracle_is_ranked_then_full_confirmed(monkeypatch):
+    target = b"T" * 16
+    noise = b"N" * 16
+    transcript = "\n".join(
+        [
+            "QQ:" + noise.hex(),
+            "QQ:" + target.hex(),
+            "QQ:" + target.hex(),
+            "QQ:" + target.hex(),
+        ]
+    )
+    monkeypatch.setattr(
+        macos_key,
+        "_run_helper",
+        lambda *args, **kwargs: transcript,
+    )
+    calls = []
+
+    def primary(candidate):
+        calls.append(("primary", candidate))
+        return candidate == target
+
+    def full(candidate):
+        calls.append(("full", candidate))
+        return candidate == target
+
+    assert macos_key.extract_verified(
+        "qq", 42, full, primary_verify=primary
+    ) == target
+    assert calls == [("primary", target), ("full", target)]
+
+
+def test_qq_primary_miss_falls_back_to_full_oracle(monkeypatch):
+    target = b"T" * 32
+    noise = b"N" * 16
+    monkeypatch.setattr(
+        macos_key,
+        "_run_helper",
+        lambda *args, **kwargs: "\n".join(
+            ["QQ:" + target.hex(), "QQ:" + noise.hex()]
+        ),
+    )
+    primary_calls = []
+    full_calls = []
+    result = macos_key.extract_verified(
+        "qq",
+        42,
+        lambda candidate: full_calls.append(candidate) is None
+        and candidate == target,
+        primary_verify=lambda candidate: primary_calls.append(candidate) is None
+        and False,
+    )
+    assert result == target
+    assert primary_calls == [noise, target]
+    assert full_calls == [noise, target]
+
+
+def test_candidate_values_are_never_written_to_output_or_logs(
+    monkeypatch, capsys, caplog
+):
+    secret = b"do-not-log-this!"
+    monkeypatch.setattr(
+        macos_key,
+        "_run_helper",
+        lambda *args, **kwargs: "QQ:" + secret.hex(),
+    )
+    assert macos_key.extract_verified(
+        "qq", 42, lambda candidate: candidate == secret
+    ) == secret
+    captured = capsys.readouterr()
+    assert secret.decode() not in captured.out
+    assert secret.decode() not in captured.err
+    assert secret.decode() not in caplog.text
+
+
+def test_extract_verified_never_returns_unverified(monkeypatch):
+    monkeypatch.setattr(
+        macos_key,
+        "_run_helper",
+        lambda *args, **kwargs: "WX:" + ("11" * 32) + "\nWX:" + ("22" * 32),
+    )
+    assert macos_key.extract_verified(
+        "wechat", 42, lambda key: key == b"\x22" * 32
+    ) == b"\x22" * 32
+    assert macos_key.extract_verified("wechat", 42, lambda key: False) is None
+
+
+def test_elevated_helper_uses_valid_applescript_string(monkeypatch, tmp_path):
+    helper = tmp_path / "scanner"
+    helper.write_text("", encoding="utf-8")
+    monkeypatch.setattr(macos_key, "ensure_helper", lambda: helper)
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(macos_key.subprocess, "run", fake_run)
+    macos_key._run_helper("wechat", 42, elevate=True, timeout=10)
+    assert seen["argv"][:2] == ["osascript", "-e"]
+    assert seen["argv"][2].startswith('do shell script "')
+    assert seen["argv"][2].endswith('" with administrator privileges')
+
+
+def test_last_error_normalizes_access_and_cancel(monkeypatch):
+    monkeypatch.setattr(macos_key, "_LAST_ERROR", "task_for_pid:5")
+    assert macos_key.last_error() == "process_access_denied"
+    monkeypatch.setattr(
+        macos_key,
+        "_LAST_ERROR",
+        "0:157: execution error: task_for_pid:5 (3)",
+    )
+    assert macos_key.last_error() == "process_access_denied"
+    monkeypatch.setattr(macos_key, "_LAST_ERROR", "execution error: User canceled. (-128)")
+    assert macos_key.last_error() == "authorization_cancelled"
+    monkeypatch.setattr(macos_key, "_LAST_ERROR", "execution error (-60007)")
+    assert macos_key.last_error() == "authorization_interaction_unavailable"
+
+
+def test_helper_timeout_is_reported_without_traceback(monkeypatch, tmp_path):
+    helper = tmp_path / "scanner"
+    helper.write_text("", encoding="utf-8")
+    monkeypatch.setattr(macos_key, "ensure_helper", lambda: helper)
+
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs.get("timeout", 1))
+
+    monkeypatch.setattr(macos_key.subprocess, "run", timeout)
+    assert macos_key._run_helper("wechat", 42, elevate=False, timeout=1) == ""
+    assert macos_key.last_error() == "helper_timeout"
+
+
+def test_helper_nonzero_exit_discards_candidate_stdout(
+    monkeypatch, tmp_path
+):
+    helper = tmp_path / "scanner"
+    helper.write_text("", encoding="utf-8")
+    monkeypatch.setattr(macos_key, "ensure_helper", lambda: helper)
+    candidate = "QQ:" + (b"A" * 16).hex()
+
+    def failed(*args, **kwargs):
+        return type(
+            "Result",
+            (),
+            {"returncode": 7, "stdout": candidate, "stderr": "scan_failed"},
+        )()
+
+    monkeypatch.setattr(macos_key.subprocess, "run", failed)
+    for elevate in (False, True):
+        assert (
+            macos_key._run_helper(
+                "qq", 42, elevate=elevate, timeout=10
+            )
+            == ""
+        )
+        assert macos_key.last_error() == "scan_failed"
+
+
+def test_prebuilt_helper_avoids_runtime_compiler(monkeypatch, tmp_path):
+    prebuilt = tmp_path / "bundle" / "macos_memory_scan"
+    prebuilt.parent.mkdir()
+    prebuilt.write_bytes(b"prebuilt-mach-helper")
+    data_root = tmp_path / "data"
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        stdout = _debugger_entitlements_xml() if "--entitlements" in argv and "-d" in argv else ""
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": stdout, "stderr": ""},
+        )()
+
+    monkeypatch.setattr(macos_key.sys, "platform", "darwin")
+    monkeypatch.setattr(macos_key, "_prebuilt_path", lambda: prebuilt)
+    monkeypatch.setattr(macos_key, "data_dir", lambda: data_root)
+    monkeypatch.setattr(macos_key.subprocess, "run", fake_run)
+
+    helper = macos_key.ensure_helper()
+    assert helper is not None
+    assert helper.read_bytes() == b"prebuilt-mach-helper"
+    assert all(argv[0] != "xcrun" for argv in calls)
+    signing_calls = [
+        argv for argv in calls
+        if argv[0] == "codesign" and "--force" in argv
+    ]
+    assert len(signing_calls) == 1
+    assert "--entitlements" in signing_calls[0]
+
+
+def test_existing_helper_without_debugger_entitlement_is_replaced(
+    monkeypatch, tmp_path
+):
+    prebuilt = tmp_path / "bundle" / "macos_memory_scan"
+    prebuilt.parent.mkdir()
+    prebuilt.write_bytes(b"new-prebuilt-mach-helper")
+    data_root = tmp_path / "data"
+    calls = []
+
+    monkeypatch.setattr(macos_key.sys, "platform", "darwin")
+    monkeypatch.setattr(macos_key, "_prebuilt_path", lambda: prebuilt)
+    monkeypatch.setattr(macos_key, "data_dir", lambda: data_root)
+
+    helper = macos_key._helper_path()
+    helper.parent.mkdir(parents=True)
+    helper.write_bytes(b"stale-helper")
+    helper.chmod(0o700)
+
+    describe_count = 0
+
+    def fake_run(argv, **kwargs):
+        nonlocal describe_count
+        calls.append(argv)
+        stdout = ""
+        if "--entitlements" in argv and "-d" in argv:
+            describe_count += 1
+            if describe_count >= 2:
+                stdout = _debugger_entitlements_xml()
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": stdout, "stderr": ""},
+        )()
+
+    monkeypatch.setattr(macos_key.subprocess, "run", fake_run)
+    rebuilt = macos_key.ensure_helper()
+    assert rebuilt == helper
+    assert rebuilt.read_bytes() == b"new-prebuilt-mach-helper"
+    assert any(argv[0] == "codesign" and "--force" in argv for argv in calls)

--- a/tests/test_macos_platform.py
+++ b/tests/test_macos_platform.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from chatlog_keeper.core import _macos
+from chatlog_keeper import qq_db, wechat_db
+
+
+def test_macos_process_pids_match_real_app_binary_only(monkeypatch):
+    monkeypatch.setattr(_macos, "is_macos", lambda: True)
+    stdout = "\n".join(
+        [
+            " 42 /Applications/WeChat.app/Contents/MacOS/WeChat",
+            " 44 /Applications/WeChat.app/Contents/Frameworks/Helper",
+            " 43 /Applications/QQ.app/Contents/MacOS/QQ",
+            " 99 /tmp/QQ",
+        ]
+    )
+    monkeypatch.setattr(
+        _macos.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout=stdout),
+    )
+    assert _macos.process_pids(("WeChat", "QQ")) == [42, 43]
+
+
+def test_macos_exact_executable_pid_uses_comm_not_argument_substrings(
+    monkeypatch,
+):
+    monkeypatch.setattr(_macos, "is_macos", lambda: True)
+    expected = Path("/Applications/QQ.app/Contents/MacOS/QQ")
+    stdout = "\n".join(
+        [
+            f" 43 {expected}",
+            f" 44 {expected} --flag",
+            f" 45 /usr/bin/python3 {expected}",
+        ]
+    )
+    monkeypatch.setattr(
+        _macos.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout=stdout),
+    )
+    assert _macos.process_pids_for_executable(expected) == [43]
+
+
+def test_macos_process_pids_fail_closed_off_macos(monkeypatch):
+    monkeypatch.setattr(_macos, "is_macos", lambda: False)
+    monkeypatch.setattr(
+        _macos.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("ps must not run")),
+    )
+    assert _macos.process_pids(("WeChat",)) == []
+
+
+def test_macos_exact_executable_pid_match(monkeypatch):
+    monkeypatch.setattr(_macos, "is_macos", lambda: True)
+    exact = Path("/tmp/WeChat-copy.app/Contents/MacOS/WeChat")
+    stdout = f" 7 {exact}\n 8 {exact} --flag\n 9 /Applications/WeChat.app/Contents/MacOS/WeChat"
+    monkeypatch.setattr(
+        _macos.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout=stdout),
+    )
+    assert _macos.process_pids_for_executable(exact) == [7]
+
+
+def test_macos_container_candidates_are_bounded():
+    home = Path("/Users/tester")
+    wechat = _macos.wechat_data_roots(home)
+    qq = _macos.qq_container_roots(home)
+    assert wechat[0] == home / "Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files"
+    assert "5A4RE8SF68.com.tencent.xinWeChat" in str(wechat[1])
+    assert qq == [
+        home / "Library/Containers/com.tencent.qq/Data",
+        home / "Library/Group Containers/FN2V63AD2J.com.tencent",
+    ]
+
+
+def test_wechat_resolver_finds_macos_container(monkeypatch, tmp_path):
+    root = tmp_path / "xwechat_files"
+    root.mkdir()
+    monkeypatch.delenv("CHATLOG_WECHAT_DATA_ROOT", raising=False)
+    monkeypatch.setattr(wechat_db.sys, "platform", "darwin")
+    monkeypatch.setattr(_macos, "wechat_data_roots", lambda: [root])
+    assert wechat_db.find_weixin_data_root() == root
+
+
+def test_qq_resolver_finds_macos_legacy_layout(monkeypatch, tmp_path):
+    data = tmp_path / "Data"
+    root = data / "Library" / "Application Support" / "QQ"
+    db = root / "opaque-account" / "nt_db" / "nt_msg.db"
+    db.parent.mkdir(parents=True)
+    db.write_bytes(b"SQLite header 3\x00" + b"\0" * 64)
+    monkeypatch.delenv("CHATLOG_QQ_DATA_ROOT", raising=False)
+    monkeypatch.setattr(qq_db.sys, "platform", "darwin")
+    monkeypatch.setattr(_macos, "qq_container_roots", lambda: [data])
+    assert qq_db.find_qq_data_root() == root
+    assert qq_db.find_msg_database(root) == db
+    assert qq_db.detect_current_qq_account() == "opaque-account"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_pyinstaller_spec_bundles_every_platform_key_helper():
+    root = Path(__file__).resolve().parents[1]
+    spec = (root / "packaging" / "chatlog_keeper.spec").read_text(encoding="utf-8")
+    for helper in (
+        "windows_ntqq_get_key.ps1",
+        "windows_wechat_get_key.ps1",
+        "macos_memory_scan.c",
+    ):
+        assert helper in spec

--- a/tests/test_qq_passive_scan.py
+++ b/tests/test_qq_passive_scan.py
@@ -1,5 +1,6 @@
 import inspect
 import time
+from pathlib import Path
 
 from chatlog_keeper import qq_db
 
@@ -54,3 +55,18 @@ def test_qq_passive_logs_never_include_key_preview():
     source = inspect.getsource(qq_db)
     assert "preview={candidate" not in source
     assert "Passphrase extracted: len={len(key)} preview=" not in source
+
+
+def test_qq_verification_read_is_bounded(monkeypatch, tmp_path):
+    db = tmp_path / "nt_msg.db"
+    db.write_bytes(b"H" * 5120 + b"unrelated trailing database pages")
+    monkeypatch.setattr(
+        Path,
+        "read_bytes",
+        lambda self: (_ for _ in ()).throw(
+            AssertionError("whole-file read is forbidden")
+        ),
+    )
+
+    value = qq_db._read_qq_verification_bytes(db)
+    assert value == b"H" * 5120

--- a/tests/test_secret_files.py
+++ b/tests/test_secret_files.py
@@ -1,0 +1,49 @@
+import json
+import os
+
+from chatlog_keeper import wechat_db
+from chatlog_keeper.core._secrets import private_binary_writer, write_secret_text
+
+
+def test_secret_write_is_atomic_and_restrictive(tmp_path):
+    target = tmp_path / "secrets" / "key"
+    assert write_secret_text(target, "first") is True
+    assert write_secret_text(target, "second") is True
+    assert target.read_text(encoding="utf-8") == "second"
+    assert not list(target.parent.glob(".key.*"))
+    if os.name != "nt":
+        assert target.stat().st_mode & 0o777 == 0o600
+        assert target.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_private_binary_write_is_atomic_and_restrictive(tmp_path):
+    target = tmp_path / "exports" / "image.jpg"
+    with private_binary_writer(target) as handle:
+        handle.write(b"\xff\xd8\xff")
+    assert target.read_bytes() == b"\xff\xd8\xff"
+    assert not list(target.parent.glob(".image.jpg.*"))
+    if os.name != "nt":
+        assert target.stat().st_mode & 0o777 == 0o600
+
+
+def test_wechat_diagnostics_never_include_key_bytes(
+    monkeypatch, tmp_path
+):
+    secret = bytes(range(32))
+    db = tmp_path / "message_0.db"
+    db.write_bytes(b"x")
+    reader = wechat_db.WeChatDBReader()
+    reader.data_root = tmp_path
+    reader.wxid_dir = tmp_path
+    reader.enc_key = secret
+    reader.enc_keys = {db: secret}
+    monkeypatch.setattr(reader, "initialize", lambda: True)
+    monkeypatch.setattr(wechat_db, "_get_weixin_pids", lambda: [])
+    monkeypatch.setattr(
+        wechat_db, "find_msg_databases", lambda root: [db]
+    )
+
+    encoded = json.dumps(reader.diagnose(), sort_keys=True)
+    assert secret.hex() not in encoded
+    assert secret.hex()[:16] not in encoded
+    assert reader.diagnose()["per_db_keys_count"] == 1

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -7,6 +7,7 @@ client and your own local data, so it is intentionally out of scope here.
 Run:  python -m pytest -q   (or simply  python tests/test_smoke.py)
 """
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -41,6 +42,9 @@ def test_export_json_and_html(tmp_path):
 
     data = json.loads((tmp_path / "m.json").read_text(encoding="utf-8"))
     assert len(data) == 3
+    if os.name != "nt":
+        assert (tmp_path / "m.json").stat().st_mode & 0o777 == 0o600
+        assert (tmp_path / "m.html").stat().st_mode & 0o777 == 0o600
 
     html = (tmp_path / "m.html").read_text(encoding="utf-8")
     assert "bubble" in html
@@ -57,6 +61,26 @@ def test_img_ext():
     assert _img_ext(b"GIF89a\x00\x00") == ".gif"
     assert _img_ext(b"RIFF\x00\x00\x00\x00WEBP") == ".webp"
     assert _img_ext(b"not-an-image") == ".bin"
+
+
+def test_image_export_creates_private_outputs(monkeypatch, tmp_path):
+    from chatlog_keeper import cli
+
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "photo.dat").write_bytes(b"encrypted")
+    monkeypatch.setattr(
+        cli.wechat_image, "decrypt_wechat_dat", lambda _path: b"\xff\xd8\xffpayload"
+    )
+
+    out = tmp_path / "private-images"
+    result = cli._decrypt_images(str(src), str(out))
+    image = out / "photo.jpg"
+    assert result["decrypted"] == 1
+    assert image.read_bytes() == b"\xff\xd8\xffpayload"
+    if os.name != "nt":
+        assert out.stat().st_mode & 0o777 == 0o700
+        assert image.stat().st_mode & 0o777 == 0o600
 
 
 if __name__ == "__main__":

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,280 @@
+import hashlib
+import hmac
+import struct
+import sys
+
+import pytest
+from Crypto.Cipher import AES
+
+from chatlog_keeper import qq_db, wechat_db
+from chatlog_keeper.core import _snapshot, _wal
+from chatlog_keeper.core._snapshot import snapshot_db_family
+
+
+def test_snapshot_copies_db_and_sidecars(tmp_path):
+    db = tmp_path / "message_0.db"
+    db.write_bytes(b"db")
+    db.with_name(db.name + "-wal").write_bytes(b"wal")
+    db.with_name(db.name + "-shm").write_bytes(b"shm")
+    with snapshot_db_family(db) as snap:
+        assert snap.read_bytes() == b"db"
+        assert snap.with_name(snap.name + "-wal").read_bytes() == b"wal"
+        assert snap.with_name(snap.name + "-shm").read_bytes() == b"shm"
+
+
+def test_snapshot_retries_when_family_changes_during_copy(tmp_path, monkeypatch):
+    db = tmp_path / "message_0.db"
+    db.write_bytes(b"db")
+    stable = (
+        ("", True, 2, 3, "a"),
+        ("-wal", False, 0, 0, ""),
+        ("-shm", False, 0, 0, ""),
+    )
+    changed = (
+        ("", True, 2, 4, "b"),
+        ("-wal", False, 0, 0, ""),
+        ("-shm", False, 0, 0, ""),
+    )
+    signatures = iter((stable, changed, changed, changed))
+    monkeypatch.setattr(_snapshot, "_family_signature", lambda _path: next(signatures))
+
+    with snapshot_db_family(db) as snap:
+        assert snap.read_bytes() == b"db"
+
+
+def test_stable_prefix_retries_checkpoint_race(tmp_path, monkeypatch):
+    db = tmp_path / "message_0.db"
+    db.write_bytes(b"A" * 4096)
+    stable = (
+        ("", True, 4096, 3, "a"),
+        ("-wal", False, 0, 0, ""),
+        ("-shm", False, 0, 0, ""),
+    )
+    changed = (
+        ("", True, 4096, 4, "b"),
+        ("-wal", True, 32, 4, "c"),
+        ("-shm", False, 0, 0, ""),
+    )
+    signatures = iter((stable, changed, changed, changed))
+    monkeypatch.setattr(
+        _snapshot,
+        "_family_signature",
+        lambda _path: next(signatures),
+    )
+
+    assert _snapshot.read_stable_prefix(db, 4096) == b"A" * 4096
+
+
+def _encrypted_page(page_key: bytes, salt: bytes, page_no: int, fill: bytes) -> bytes:
+    reserve = 80
+    prefix = salt if page_no == 1 else b""
+    body_len = 4096 - reserve - len(prefix)
+    plain = (fill * (body_len // len(fill) + 1))[:body_len]
+    iv = bytes(range(16))
+    cipher = AES.new(page_key, AES.MODE_CBC, iv).encrypt(plain)
+    mac_salt = bytes(value ^ 0x3A for value in salt)
+    mac_key = hashlib.pbkdf2_hmac("sha512", page_key, mac_salt, 2, dklen=32)
+    tag = hmac.new(
+        mac_key, cipher + iv + struct.pack("<I", page_no), hashlib.sha512
+    ).digest()
+    return prefix + cipher + iv + tag
+
+
+def _wal_bytes(frames, *, salt1=0x11223344, salt2=0x55667788):
+    magic = 0x377F0682
+    header_24 = struct.pack(
+        ">6I", magic, 3007000, 4096, 1, salt1, salt2
+    )
+    checksum = _wal._checksum_bytes(
+        header_24, big_endian=False
+    )
+    output = bytearray(header_24 + struct.pack(">II", *checksum))
+    for page_no, db_size, page in frames:
+        first = struct.pack(">II", page_no, db_size)
+        checksum = _wal._checksum_bytes(
+            first + page,
+            checksum,
+            big_endian=False,
+        )
+        output.extend(
+            first
+            + struct.pack(">II", salt1, salt2)
+            + struct.pack(">II", *checksum)
+            + page
+        )
+    return bytes(output), checksum
+
+
+def _shm_bytes(
+    *,
+    mx_frame,
+    n_page,
+    frame_checksum,
+    salt1=0x11223344,
+    salt2=0x55667788,
+):
+    native = "<" if sys.byteorder == "little" else ">"
+    header = bytearray(48)
+    struct.pack_into(f"{native}I", header, 0, 3007000)
+    header[12] = 1
+    header[13] = 0
+    struct.pack_into(f"{native}H", header, 14, 4096)
+    struct.pack_into(f"{native}II", header, 16, mx_frame, n_page)
+    struct.pack_into(f"{native}II", header, 24, *frame_checksum)
+    header[32:40] = struct.pack(">II", salt1, salt2)
+    checksum = _wal._checksum_bytes(
+        bytes(header[:40]),
+        big_endian=(sys.byteorder == "big"),
+    )
+    struct.pack_into(f"{native}II", header, 40, *checksum)
+    return bytes(header + header + bytearray(40))
+
+
+def test_wechat_wal_page_is_hmac_verified_and_decrypted():
+    key = bytes(range(32))
+    salt = bytes(range(16))
+    page = _encrypted_page(key, salt, 2, b"A")
+    plain = wechat_db._decrypt_wal_page(page, key, salt, 2)
+    assert plain is not None
+    assert plain[:4016] == b"A" * 4016
+    tampered = bytearray(page)
+    tampered[100] ^= 1
+    assert wechat_db._decrypt_wal_page(bytes(tampered), key, salt, 2) is None
+
+
+def test_apply_wechat_wal_committed_frame(tmp_path):
+    key = bytes(range(32))
+    salt = bytes(range(16))
+    output = tmp_path / "decrypted.db"
+    output.write_bytes(b"\0" * 8192)
+    wal = tmp_path / "message.db-wal"
+    page = _encrypted_page(key, salt, 2, b"B")
+    wal.write_bytes(_wal_bytes([(2, 2, page)])[0])
+    assert wechat_db._apply_wechat_wal(wal, key, salt, output) == 1
+    assert output.read_bytes()[4096:4096 + 4016] == b"B" * 4016
+
+
+def test_wal_shm_mxframe_and_checksums_are_enforced(tmp_path):
+    page = b"P" * 4096
+    wal_bytes, frame_checksum = _wal_bytes([(2, 2, page)])
+    wal = tmp_path / "message.db-wal"
+    wal.write_bytes(wal_bytes)
+    shm = tmp_path / "message.db-shm"
+    shm.write_bytes(
+        _shm_bytes(
+            mx_frame=1,
+            n_page=2,
+            frame_checksum=frame_checksum,
+        )
+    )
+    plan = _wal.inspect_wal(
+        wal, shm_path=shm, expected_page_size=4096
+    )
+    assert plan.frames_to_apply == 1
+    assert plan.commit_size == 2
+    assert plan.used_shm is True
+
+    broken = bytearray(shm.read_bytes())
+    broken[16] = 2
+    broken[64] = 2
+    shm.write_bytes(broken)
+    with pytest.raises(_wal.WalValidationError):
+        _wal.inspect_wal(wal, shm_path=shm, expected_page_size=4096)
+
+
+def test_wal_bad_header_checksum_fails_closed(tmp_path):
+    wal = tmp_path / "message.db-wal"
+    data = bytearray(_wal_bytes([(2, 2, b"P" * 4096)])[0])
+    data[24] ^= 1
+    wal.write_bytes(data)
+    with pytest.raises(_wal.WalValidationError, match="header checksum"):
+        _wal.inspect_wal(wal, expected_page_size=4096)
+
+
+def test_wal_stale_preallocated_tail_after_commit_is_ignored(tmp_path):
+    wal = tmp_path / "message.db-wal"
+    committed = _wal_bytes([(2, 2, b"P" * 4096)])[0]
+    stale_header = (
+        struct.pack(">II", 3, 3)
+        + struct.pack(">II", 0xDEADBEEF, 0xBAD0C0DE)
+        + b"\0" * 8
+    )
+    wal.write_bytes(committed + stale_header + b"S" * 4096)
+    plan = _wal.inspect_wal(wal, expected_page_size=4096)
+    assert plan.frames_to_apply == 1
+    assert plan.valid_frames == 1
+    assert plan.physical_frames == 2
+
+
+def test_wechat_wal_sqlcipher_hmac_failure_never_mutates_output(tmp_path):
+    key = bytes(range(32))
+    salt = bytes(range(16))
+    output = tmp_path / "decrypted.db"
+    original = b"\0" * 8192
+    output.write_bytes(original)
+    encrypted = bytearray(_encrypted_page(key, salt, 2, b"B"))
+    encrypted[100] ^= 1
+    wal = tmp_path / "message.db-wal"
+    # Recompute the outer SQLite WAL checksum around the tampered encrypted
+    # page so only the SQLCipher HMAC gate detects the corruption.
+    wal.write_bytes(_wal_bytes([(2, 2, bytes(encrypted))])[0])
+    with pytest.raises(_wal.WalValidationError, match="SQLCipher"):
+        wechat_db._apply_wechat_wal(wal, key, salt, output)
+    assert output.read_bytes() == original
+
+
+def _encrypted_qq_page(
+    passphrase: bytes,
+    salt: bytes,
+    page_no: int,
+    fill: bytes,
+) -> bytes:
+    reserve = 48
+    prefix = salt if page_no == 1 else b""
+    body_len = 4096 - reserve - len(prefix)
+    plain = (fill * (body_len // len(fill) + 1))[:body_len]
+    iv = bytes(reversed(range(16)))
+    aes_key = hashlib.pbkdf2_hmac(
+        "sha512", passphrase, salt, 4000, dklen=32
+    )
+    mac_salt = bytes(value ^ 0x3A for value in salt)
+    mac_key = hashlib.pbkdf2_hmac(
+        "sha512", aes_key, mac_salt, 2, dklen=32
+    )
+    cipher = AES.new(aes_key, AES.MODE_CBC, iv).encrypt(plain)
+    tag = hmac.new(
+        mac_key,
+        cipher + iv + struct.pack("<I", page_no),
+        hashlib.sha1,
+    ).digest()
+    return prefix + cipher + iv + tag + b"\0" * 12
+
+
+def test_qq_header_strip_preserves_and_applies_committed_wal(tmp_path):
+    key = b"0123456789abcdef"
+    salt = bytes(range(16))
+    source = tmp_path / "nt_msg.db"
+    source.write_bytes(
+        b"H" * 1024
+        + _encrypted_qq_page(key, salt, 1, b"A")
+        + _encrypted_qq_page(key, salt, 2, b"C")
+    )
+    wal_page = _encrypted_qq_page(key, salt, 2, b"B")
+    wal_bytes, frame_checksum = _wal_bytes([(2, 2, wal_page)])
+    source.with_name(source.name + "-wal").write_bytes(wal_bytes)
+    source.with_name(source.name + "-shm").write_bytes(
+        _shm_bytes(
+            mx_frame=1,
+            n_page=2,
+            frame_checksum=frame_checksum,
+        )
+    )
+
+    stripped = tmp_path / "stripped.db"
+    assert qq_db._skip_header(source, stripped) is True
+    assert stripped.with_name(stripped.name + "-wal").read_bytes() == wal_bytes
+    plain = tmp_path / "plain.db"
+    assert qq_db._decrypt_db_qq(stripped, key, plain) is True
+    value = plain.read_bytes()
+    assert value[:16] == b"SQLite format 3\x00"
+    assert value[4096:4096 + (4096 - 48)] == b"B" * (4096 - 48)


### PR DESCRIPTION
## What changed

- add Apple Silicon macOS discovery for QQ and WeChat data/processes
- add passive and isolated active key acquisition with DB-HMAC verification
- snapshot live SQLCipher DB/WAL/SHM families and validate committed WAL recovery
- make key caches and exported files atomic and private on POSIX
- bundle the read-only Mach helper in the standalone executable
- extend CI to Windows and macOS and publish a macOS arm64 release asset
- document macOS security, permissions, and troubleshooting in English and Chinese

## Why

Bring the existing Windows CLI/export behavior to macOS while leaving the original signed chat clients untouched, keeping SIP enabled, and preserving the local-only/no-telemetry boundary.

## User impact

The package version becomes 0.2.0. Windows behavior remains supported. Apple Silicon users gain the same probe, key-cache, export, JSON/HTML, and image workflows, with administrator authorization required only for the isolated active-key fallback.

## Validation

- Windows Python 3.9: 78 passed
- Apple Silicon Mac: 78 passed
- Ruff: all checks passed
- compileall: passed
- Windows/Mac source parity: 32/32
- standalone arm64 executable: Mach-O arm64, strict codesign verification and `--help` smoke passed
- public pre-audit: no secrets, personal machine identifiers, unsafe shell execution, unsafe deserialization, runtime network client code, or key logging found